### PR TITLE
Fixed connection parameter for connection_created signal

### DIFF
--- a/lib/mysql/connector/django/base.py
+++ b/lib/mysql/connector/django/base.py
@@ -584,7 +584,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         cnx = mysql.connector.connect(**conn_params)
         self.server_version = cnx.get_server_version()
         cnx.set_converter_class(DjangoMySQLConverter)
-        connection_created.send(sender=self.__class__, connection=cnx)
 
         return cnx
 


### PR DESCRIPTION
connection_created should receive mysql connection as an argument according to https://docs.djangoproject.com/en/1.7/ref/signals/#connection-created
