### PR TITLE
connection_created.send removed from mysql-connector django backend

### DIFF
--- a/lib/mysql/connector/django/base.py
+++ b/lib/mysql/connector/django/base.py
@@ -584,7 +584,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         cnx = mysql.connector.connect(**conn_params)
         self.server_version = cnx.get_server_version()
         cnx.set_converter_class(DjangoMySQLConverter)
-        connection_created.send(sender=self.__class__, connection=cnx)
 
         return cnx
 


### PR DESCRIPTION
This signal is automatically sent by django.db.backends
https://github.com/django/django/blob/b2aad7b836bfde012756cca69291c14d2fdbd334/django/db/backends/__init__.py
