### PR TITLE
Support for connection attributes

### DIFF
--- a/lib/mysql/connector/connection.py
+++ b/lib/mysql/connector/connection.py
@@ -90,6 +90,7 @@ class MySQLConnection(MySQLConnectionAbstract):
         self._ssl_active = False
         self._auth_plugin = None
         self._pool_config_version = None
+        self._connattrs = None
 
         if len(kwargs) > 0:
             self.connect(**kwargs)
@@ -117,7 +118,7 @@ class MySQLConnection(MySQLConnectionAbstract):
         self._handshake = handshake
 
     def _do_auth(self, username=None, password=None, database=None,
-                 client_flags=0, charset=33, ssl_options=None):
+                 client_flags=0, charset=33, ssl_options=None, connattrs=None):
         """Authenticate with the MySQL server
 
         Authentication happens in two parts. We first send a response to the
@@ -140,7 +141,8 @@ class MySQLConnection(MySQLConnectionAbstract):
             username=username, password=password, database=database,
             charset=charset, client_flags=client_flags,
             ssl_enabled=self._ssl_active,
-            auth_plugin=self._auth_plugin)
+            auth_plugin=self._auth_plugin,
+            connattrs=connattrs)
         self._socket.send(packet)
         self._auth_switch_request(username, password)
 
@@ -211,7 +213,7 @@ class MySQLConnection(MySQLConnectionAbstract):
         self._do_handshake()
         self._do_auth(self._user, self._password,
                       self._database, self._client_flags, self._charset_id,
-                      self._ssl)
+                      self._ssl, self._connattrs)
         self.set_converter_class(self._converter_class)
         if self._client_flags & ClientFlag.COMPRESS:
             self._socket.recv = self._socket.recv_compressed

--- a/lib/mysql/connector/connection.py
+++ b/lib/mysql/connector/connection.py
@@ -113,6 +113,7 @@ class MySQLConnection(MySQLConnectionAbstract):
         if handshake['capabilities'] & ClientFlag.PLUGIN_AUTH:
             self.set_client_flags([ClientFlag.PLUGIN_AUTH])
 
+        self.set_client_flags([ClientFlag.CONNECT_ARGS])
         self._handshake = handshake
 
     def _do_auth(self, username=None, password=None, database=None,

--- a/lib/mysql/connector/constants.py
+++ b/lib/mysql/connector/constants.py
@@ -64,6 +64,7 @@ DEFAULT_CONFIGURATION = {
     'auth_plugin': None,
     'allow_local_infile': True,
     'consume_results': False,
+    'connattrs': None,
 }
 
 CNX_POOL_ARGS = ('pool_name', 'pool_size', 'pool_reset_session')


### PR DESCRIPTION
This makes it possible to send connection attributes.

By default _client_name and _client_version will be send.

Custom attributes can be used with the connattrs dict.

Maybe set 'program_name' to sys.argv[0] by default? and maybe also set '_pid' just like libmysql?
I didn't add anything to the testsuite.
I didn't test with cext.

```
$ cat test.py 
#!/usr/bin/env python
import sys
import mysql.connector

conn = mysql.connector.connect(host='127.0.0.1',user='msandbox',password='msandbox',port=5707)
cur = conn.cursor()
cur.execute('SELECT * FROM performance_schema.session_connect_attrs')
for res in cur:
    print(res)
cur.close()
conn.close()

conn = mysql.connector.connect(host='127.0.0.1',user='msandbox',password='msandbox',port=5707, connattrs={'foo': 'bar', 'program_name': sys.argv[0]})
cur = conn.cursor()
cur.execute('SELECT * FROM performance_schema.session_connect_attrs')
for res in cur:
    print(res)
cur.close()
conn.close()
$ ./test.py 
(63, bytearray(b'_client_version'), bytearray(b'2.1.1a1'), 0)
(63, bytearray(b'_client_name'), bytearray(b'MySQL Connector/Python'), 1)
(64, bytearray(b'_client_version'), bytearray(b'2.1.1a1'), 0)
(64, bytearray(b'program_name'), bytearray(b'./test.py'), 1)
(64, bytearray(b'foo'), bytearray(b'bar'), 2)
(64, bytearray(b'_client_name'), bytearray(b'MySQL Connector/Python'), 3)
```