### PR TITLE
fix Connection not available after return connection to pool 

### DIFF
--- a/lib/mysql/connector/pooling.py
+++ b/lib/mysql/connector/pooling.py
@@ -113,10 +113,13 @@ class PooledMySQLConnection(object):
         state will be cleared by re-authenticating the user.
         """
         cnx = self._cnx
-        if self._cnx_pool.reset_session:
-            cnx.reset_session()
+        try:
+            if self._cnx_pool.reset_session:
+                cnx.reset_session()
 
-        self._cnx_pool.add_connection(cnx)
+            self._cnx_pool.add_connection(cnx)
+        except errors.OperationalError as e:
+            self._cnx_pool.add_connection()
         self._cnx = None
 
     def config(self, **kwargs):


### PR DESCRIPTION
I found that, when I use PooledMySQLConnection, and when close PooledMySQLConnection (actually it do return the connection back to pool), and at the same time if this connection is broken such as timeout, it will raise exception, and will never return back the pool. 

```python
cnx = self._cnx
cnx.reset_session()  # raise exception
self._cnx_pool.add_connection(cnx)
```

finally, when each connection in poll meet this, it will cause `pool exhausted`