### PR TITLE
Fix `error: option --single-version-externally-managed not recognized` when installing from `pip`.

### DIFF
--- a/lib/cpy_distutils.py
+++ b/lib/cpy_distutils.py
@@ -24,9 +24,15 @@
 """Implements the DistUtils command 'build_ext'
 """
 
-from distutils.command.build_ext import build_ext
-from distutils.command.install import install
-from distutils.command.install_lib import install_lib
+try:
+    from setuptools.command.build_ext import build_ext
+    from setuptools.command.install import install
+    from setuptools.command.install_lib import install_lib
+except ImportError:
+    from distutils.command.build_ext import build_ext
+    from distutils.command.install import install
+    from distutils.command.install_lib import install_lib
+
 from distutils.errors import DistutilsExecError
 from distutils.util import get_platform
 from distutils.dir_util import copy_tree


### PR DESCRIPTION
This patch fixes the following problem when installing using certain versions of `pip`/`setuptools` (attempted on Debian jessie):

```sh
vagrant@bad:~$ git clone https://github.com/mysql/mysql-connector-python.git mysql-mysql-connector-python
Cloning into 'mysql-mysql-connector-python'...
remote: Counting objects: 1560, done.
remote: Total 1560 (delta 0), reused 0 (delta 0), pack-reused 1559
Receiving objects: 100% (1560/1560), 675.71 KiB | 685.00 KiB/s, done.
Resolving deltas: 100% (913/913), done.
Checking connectivity... done.
vagrant@bad:~$ python -m virtualenv ./test-mysql-connectorRunning virtualenv with interpreter /usr/bin/python2
New python executable in ./test-mysql-connector/bin/python2
Also creating executable in ./test-mysql-connector/bin/python
Installing setuptools, pip...done.
vagrant@bad:~$ ./test-mysql-connector/bin/pip install ./mysql-mysql-connector-python
Unpacking ./mysql-mysql-connector-python
  Running setup.py (path:/tmp/pip-Ln020b-build/setup.py) egg_info for package from file:///home/vagrant/mysql-mysql-connector-python

Installing collected packages: mysql-connector-python
  Running setup.py install for mysql-connector-python
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
       or: -c --help [cmd1 cmd2 ...]
       or: -c --help-commands
       or: -c cmd --help

    error: option --single-version-externally-managed not recognized
    Complete output from command /home/vagrant/test-mysql-connector/bin/python2 -c "import setuptools, tokenize;__file__='/tmp/pip-Ln020b-build/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-eXmiqs-record/install-record.txt --single-version-externally-managed --compile --install-headers /home/vagrant/test-mysql-connector/include/site/python2.7:
    usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]

   or: -c --help [cmd1 cmd2 ...]

   or: -c --help-commands

   or: -c cmd --help



error: option --single-version-externally-managed not recognized

----------------------------------------
Cleaning up...
Command /home/vagrant/test-mysql-connector/bin/python2 -c "import setuptools, tokenize;__file__='/tmp/pip-Ln020b-build/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --record /tmp/pip-eXmiqs-record/install-record.txt --single-version-externally-managed --compile --install-headers /home/vagrant/test-mysql-connector/include/site/python2.7 failed with error code 1 in /tmp/pip-Ln020b-build
Storing debug log for failure in /home/vagrant/.pip/pip.log
```

This patch uses a [similar technique to llvmlite](https://github.com/lungothrin/llvmlite/commit/cdf6497dc6e37efe5e67ffd675513145d421a1e7) (explained [here](https://github.com/Homebrew/homebrew-python/issues/132#issuecomment-68668771)). After the patch:

```sh
vagrant@bad:~$ git clone --branch posita/fix-broken-use-of-distutils https://github.com/posita/mysql-connector-python.git posita-mysql-connector-python Cloning into 'posita-mysql-connector-python'...
remote: Counting objects: 1564, done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 1564 (delta 0), reused 0 (delta 0), pack-reused 1559
Receiving objects: 100% (1564/1564), 682.01 KiB | 899.00 KiB/s, done.
Resolving deltas: 100% (913/913), done.
Checking connectivity... done.
vagrant@bad:~$ python -m virtualenv ./test-mysql-connector-fixed
Running virtualenv with interpreter /usr/bin/python2
New python executable in ./test-mysql-connector-fixed/bin/python2
Also creating executable in ./test-mysql-connector-fixed/bin/python
Installing setuptools, pip...done.
vagrant@bad:~$ ./test-mysql-connector-fixed/bin/pip install ./posita-mysql-connector-python
Unpacking ./posita-mysql-connector-python
  Running setup.py (path:/tmp/pip-iwmOVU-build/setup.py) egg_info for package from file:///home/vagrant/posita-mysql-connector-python

Installing collected packages: mysql-connector-python
  Running setup.py install for mysql-connector-python
    Not Installing C Extension

Successfully installed mysql-connector-python
Cleaning up...
```