### PR TITLE
Convert rows in MySQLCursorPrepared

### DIFF
--- a/lib/mysql/connector/cursor.py
+++ b/lib/mysql/connector/cursor.py
@@ -1174,8 +1174,10 @@ class MySQLCursorPrepared(MySQLCursor):
     def fetchall(self):
         if not self._have_unread_result():
             raise errors.InterfaceError("No result set to fetch from.")
-        (rows, eof) = self._connection.get_rows(
-            binary=self._binary, columns=self.description)
+        (rows, eof) = self._connection.get_rows()
+
+        if self._nextrow[0]:
+            rows.insert(0, self._nextrow[0])
 
         if hasattr(self._connection, 'converter'):
             row_to_python = self._connection.converter.row_to_python


### PR DESCRIPTION
Properly convert rows into Python format, e.g. convert bytearray to unicode.

There should be something in the base class MySQLCursor instead of copying the code.