### PR TITLE
Allow to only specify the CA w/ CEXT

### DIFF
--- a/src/mysql_capi.c
+++ b/src/mysql_capi.c
@@ -1043,7 +1043,7 @@ MySQL_connect(MySQL *self, PyObject *args, PyObject *kwds)
 		NULL
     };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|zzzzkzksssO!O!", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|zzzzkzkzzzO!O!", kwlist,
                                      &host, &user, &password, &database,
                                      &port, &unix_socket,
                                      &client_flags,


### PR DESCRIPTION
See https://gist.github.com/dveeden/84ae02e5009fe71fa094

If using the C Extension for MySQL Connector/Python then only using a ssl_ca raises an exception.
This fixes that.