### PR TITLE
mysql.connector.protocol: don't crash when the packet is fully processed in parse_auth_switch_request

### DIFF
--- a/lib/mysql/connector/protocol.py
+++ b/lib/mysql/connector/protocol.py
@@ -711,7 +711,7 @@ class MySQLProtocol(object):
                 "Failed parsing AuthSwitchRequest packet")
 
         (packet, plugin_name) = utils.read_string(packet[5:], end=b'\x00')
-        if packet[-1] == 0:
+        if packet and packet[-1] == 0:
             packet = packet[:-1]
 
         return plugin_name.decode('utf8'), packet


### PR DESCRIPTION
While testing pam authentication (ssl + cleartext plugin), I got the following crash:

```
Traceback (most recent call last):
  File "pamtest.py", line 60, in <module>
    main()
  File "pamtest.py", line 22, in main
    test_connector(opts)
  File "pamtest.py", line 55, in test_connector
    conn = mysql.connect(option_files=['/home/dennis/odbc-test/.my.cnf'])
  File "/usr/lib/python2.7/dist-packages/mysql/connector/__init__.py", line 143, in connect
    return connect(**new_config)
  File "/usr/lib/python2.7/dist-packages/mysql/connector/__init__.py", line 179, in connect
    return MySQLConnection(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/mysql/connector/connection.py", line 95, in __init__
    self.connect(**kwargs)
  File "/usr/lib/python2.7/dist-packages/mysql/connector/abstracts.py", line 719, in connect
    self._open_connection()
  File "/usr/lib/python2.7/dist-packages/mysql/connector/connection.py", line 210, in _open_connection
    self._ssl)
  File "/usr/lib/python2.7/dist-packages/mysql/connector/connection.py", line 144, in _do_auth
    self._auth_switch_request(username, password)
  File "/usr/lib/python2.7/dist-packages/mysql/connector/connection.py", line 166, in _auth_switch_request
    auth_data) = self._protocol.parse_auth_switch_request(packet)
  File "/usr/lib/python2.7/dist-packages/mysql/connector/protocol.py", line 714, in parse_auth_switch_request
    if packet[-1] == 0:
```

This simple patch avoids that and makes cleartext authentication work