### PR TITLE
batch_insert should use python charset for encoding, not mysql (e.g. …

### DIFF
--- a/lib/mysql/connector/cursor.py
+++ b/lib/mysql/connector/cursor.py
@@ -543,11 +543,11 @@ class MySQLCursor(CursorBase):
                 "Failed rewriting statement for multi-row INSERT. "
                 "Check SQL syntax."
             )
-        fmt = matches.group(1).encode(self._connection.charset)
+        fmt = matches.group(1).encode(self._connection.python_charset)
         values = []
 
         try:
-            stmt = operation.encode(self._connection.charset)
+            stmt = operation.encode(self._connection.python_charset)
             for params in seq_params:
                 tmp = fmt
                 if isinstance(params, dict):


### PR DESCRIPTION
…utf8 instead of utf8mb4)

Signed-off-by: imreFitos <imre.fitos@gmail.com>