### PR TITLE
Guarantee file closing of input files in optionfiles module

### DIFF
--- a/lib/mysql/connector/optionfiles.py
+++ b/lib/mysql/connector/optionfiles.py
@@ -239,19 +239,20 @@ class MySQLOptionsParser(SafeConfigParser):  # pylint: disable=R0901
         for priority, filename in enumerate(filenames):
             try:
                 out_file = io.StringIO()
-                for line in codecs.open(filename, encoding='utf-8'):
-                    line = line.strip()
-                    match_obj = self.OPTCRE.match(line)
-                    if not self.SECTCRE.match(line) and match_obj:
-                        optname, delimiter, optval = match_obj.group('option',
-                                                                     'vi',
-                                                                     'value')
-                        if optname and not optval and not delimiter:
-                            out_file.write(line + "=\n")
+                with codecs.open(filename, encoding='utf-8') as in_file:
+                    for line in in_file(filename, encoding='utf-8'):
+                        line = line.strip()
+                        match_obj = self.OPTCRE.match(line)
+                        if not self.SECTCRE.match(line) and match_obj:
+                            optname, delimiter, optval = match_obj.group('option',
+                                                                         'vi',
+                                                                         'value')
+                            if optname and not optval and not delimiter:
+                                out_file.write(line + "=\n")
+                            else:
+                                out_file.write(line + '\n')
                         else:
                             out_file.write(line + '\n')
-                    else:
-                        out_file.write(line + '\n')
                 out_file.seek(0)
             except IOError:
                 continue


### PR DESCRIPTION
With Python3, using the `-b` parameter (to enable `ResourceWarning` notifications), one gets the following when loading one or more option files:
```
mysql-connector/mysql/connector/optionfiles.py:242: ResourceWarning: unclosed file <_io.BufferedReader name='./my.cnf'>
```

This patch should address the issue by wrapping `codes.open` in a `with` statement.