### PR TITLE
Add support for Decimal parsing in protocol.py

### DIFF
--- a/lib/mysql/connector/protocol.py
+++ b/lib/mysql/connector/protocol.py
@@ -440,6 +440,9 @@ class MySQLProtocol(object):
             elif field[1] == FieldType.TIME:
                 (packet, value) = self._parse_binary_time(packet, field)
                 values.append(value)
+            elif field[1] in (FieldType.DECIMAL, FieldType.NEWDECIMAL):
+                (packet, value) = utils.read_lc_string(packet)
+                values.append(Decimal(str(val, encoding="utf-8")))
             else:
                 (packet, value) = utils.read_lc_string(packet)
                 values.append(value)

--- a/lib/mysql/connector/protocol.py
+++ b/lib/mysql/connector/protocol.py
@@ -442,7 +442,7 @@ class MySQLProtocol(object):
                 values.append(value)
             elif field[1] in (FieldType.DECIMAL, FieldType.NEWDECIMAL):
                 (packet, value) = utils.read_lc_string(packet)
-                values.append(Decimal(str(val, encoding="utf-8")))
+                values.append(Decimal(str(value, encoding="utf-8")))
             else:
                 (packet, value) = utils.read_lc_string(packet)
                 values.append(value)


### PR DESCRIPTION
Currently a Decimal when queried from MySQLCursorPrepared is returned as a bytearray.  The api states that the values FieldType.DECIMAL, FieldType.NEWDECIMAL are just a char array which I guess is why it's parsed by the string parser already. 

I haven't tested the encoding on py2 but wanted feedback on whether this is a fix that would be included. I can add support/test if this seems reasonable.

It seem appropriate to convert these to Decimal here because the code notes that this should be done.
```python
    def _row_to_python(self, rowdata, desc=None):
        """Convert row data from MySQL to Python types

        The conversion is done while reading binary data in the
        protocol module.
        """
        pass
```