### PR TITLE
Add MySQLCursorPreparedDict option

### DIFF
--- a/lib/mysql/connector/connection.py
+++ b/lib/mysql/connector/connection.py
@@ -41,7 +41,7 @@ from .cursor import (
     CursorBase, MySQLCursor, MySQLCursorRaw,
     MySQLCursorBuffered, MySQLCursorBufferedRaw, MySQLCursorPrepared,
     MySQLCursorDict, MySQLCursorBufferedDict, MySQLCursorNamedTuple,
-    MySQLCursorBufferedNamedTuple)
+    MySQLCursorBufferedNamedTuple, MySQLCursorPreparedDict)
 from .network import MySQLUnixSocket, MySQLTCPSocket
 from .protocol import MySQLProtocol
 from .utils import int4store
@@ -835,7 +835,8 @@ class MySQLConnection(MySQLConnectionAbstract):
             5: MySQLCursorBufferedDict,
             8: MySQLCursorNamedTuple,
             9: MySQLCursorBufferedNamedTuple,
-            16: MySQLCursorPrepared
+            16: MySQLCursorPrepared,
+            20: MySQLCursorPreparedDict
         }
         try:
             return (types[cursor_type])(self)

--- a/lib/mysql/connector/cursor.py
+++ b/lib/mysql/connector/cursor.py
@@ -1175,6 +1175,20 @@ class MySQLCursorPrepared(MySQLCursor):
         return rows
 
 
+class MySQLCursorPreparedDict(MySQLCursorPrepared):
+    def fetchone(self):
+        row = super().fetchone()
+        return dict(zip(self.column_names, row)) if row else None
+
+    def fetchmany(self, size=None):
+        rows = super().fetchmany(size=size)
+        return [dict(zip(self.column_names, row)) for row in rows]
+
+    def fetchall(self):
+        rows = super().fetchall()
+        return [dict(zip(self.column_names, row)) for row in rows]
+
+
 class MySQLCursorDict(MySQLCursor):
     """
     Cursor fetching rows as dictionaries.


### PR DESCRIPTION
Some like Dict, some like Prepared, but I like both sometimes as well. 

MySQLCursorPreparedDict subclasses MySQLCursorPrepared and fetch*() with the desired behavior to map column names to fields in dictionary format.