### PR TITLE
distutils build process fails when installing from source directly

### DIFF
--- a/lib/cpy_distutils.py
+++ b/lib/cpy_distutils.py
@@ -24,9 +24,10 @@
 """Implements the DistUtils command 'build_ext'
 """
 
-from distutils.command.build_ext import build_ext
-from distutils.command.install import install
-from distutils.command.install_lib import install_lib
+from setuptools.command.build_ext import build_ext
+from setuptools.command.install import install
+from setuptools.command.install_lib import install_lib
+
 from distutils.errors import DistutilsExecError
 from distutils.util import get_platform
 from distutils.dir_util import copy_tree

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ To install MySQL Connector/Python:
 
 """
 
-from distutils.core import setup
+from setuptools import setup
 from distutils.command.install import INSTALL_SCHEMES
 
 # Make sure that data files are actually installed in the package directory

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -21,7 +21,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-from distutils.core import Extension
+from setuptools import Extension
 import os
 import sys
 


### PR DESCRIPTION
When installing from source directly without the annoying cpyint submodule that can't be checked out of course:

> pip install git+ssh://git@github.com/lukeweber/mysql-connector-python.git#egg=mysql-connector-python==2.1.3 --upgrade

==========
....
    error: option --single-version-externally-managed not recognized

    ----------------------------------------
  Rolling back uninstall of mysql-connector-python/
....

When installing with this branch, it works fine. Also when building a wheel and then installing the wheel it seems to work fine with master, but was explained below.

I read up on distutils vs setuptools a bit:
http://stackoverflow.com/questions/25337706/setuptools-vs-distutils-why-is-distutils-still-a-thing

Noticed that "Even for projects that do choose to use distutils, when pip installs such projects directly from source (rather than installing from a prebuilt wheel file), it will actually build your project using setuptools instead."

I'm not sure of all the build options as I'm not extremely familiar with distutils, but seems that using them directly is not encouraged in many cases and that setuptools adds more metadata to packages and wraps distutils. I've verified that for my simple python only installation still works and is identical as before, and built with the option --with-mysql-capi= and seemed to build just fine as well.