### PR TITLE
Fix unclosed socket on constructor (connection) failure

### DIFF
--- a/lib/mysql/connector/connection.py
+++ b/lib/mysql/connector/connection.py
@@ -92,7 +92,12 @@ class MySQLConnection(MySQLConnectionAbstract):
         self._pool_config_version = None
 
         if len(kwargs) > 0:
-            self.connect(**kwargs)
+            try:
+                self.connect(**kwargs)
+            except:
+                # Tidy-up underlying socket on failure
+                self.close()
+                raise
 
     def _do_handshake(self):
         """Get the handshake from the MySQL server"""
@@ -223,6 +228,7 @@ class MySQLConnection(MySQLConnectionAbstract):
             self._socket.shutdown()
         except (AttributeError, errors.Error):
             pass  # Getting an exception would mean we are disconnected.
+        self._socket = None
 
     def close(self):
         """Disconnect from the MySQL server"""
@@ -234,6 +240,8 @@ class MySQLConnection(MySQLConnectionAbstract):
             self._socket.close_connection()
         except (AttributeError, errors.Error):
             pass  # Getting an exception would mean we are disconnected.
+        self._socket = None
+
     disconnect = close
 
     def _send_cmd(self, command, argument=None, packet_number=0, packet=None,


### PR DESCRIPTION
Creating a [Connection](https://github.com/mysql/mysql-connector-python/blob/master/lib/mysql/connector/connection.py#L51) instance (with `use_pure=True`) and e.g. specifying an invalid password causes a `ResourceWarning` (if running python 3 with `-b` flag) as the underlying socket is not closed in such a case. This patch addresses this problem.