### PR TITLE
Warning behaviour improvements

### DIFF
--- a/lib/mysql/connector/abstracts.py
+++ b/lib/mysql/connector/abstracts.py
@@ -559,7 +559,9 @@ class MySQLConnectionAbstract(object):
         if not isinstance(value, bool):
             raise ValueError("Expected a boolean type")
         self._raise_on_warnings = value
-        self._get_warnings = value
+        # don't disable warning retrieval if raising explicitly disabled
+        if value:
+            self._get_warnings = value
 
 
     @property

--- a/lib/mysql/connector/connection.py
+++ b/lib/mysql/connector/connection.py
@@ -229,11 +229,12 @@ class MySQLConnection(MySQLConnectionAbstract):
         if not self._socket:
             return
 
-        try:
-            self.cmd_quit()
-            self._socket.close_connection()
-        except (AttributeError, errors.Error):
-            pass  # Getting an exception would mean we are disconnected.
+        for action in (self.cmd_quit, self._socket.close_connection):
+            try:
+                action()
+            except (AttributeError, errors.Error):
+                pass  # Getting an exception would mean we are disconnected.
+
     disconnect = close
 
     def _send_cmd(self, command, argument=None, packet_number=0, packet=None,

--- a/lib/mysql/connector/cursor.py
+++ b/lib/mysql/connector/cursor.py
@@ -26,6 +26,7 @@
 
 from collections import namedtuple
 import re
+import warnings
 import weakref
 
 from . import errors
@@ -341,7 +342,12 @@ class MySQLCursor(CursorBase):
         if self._connection is None:
             return False
 
-        self._connection.handle_unread_result()
+        try:
+            self._connection.handle_unread_result()
+        except errors.InternalError as ex:
+            # Don't hide other exceptions which might have occured on closing
+            if ex.msg != "Unread result found":
+                raise
         self._reset_result()
         self._connection = None
 
@@ -399,9 +405,6 @@ class MySQLCursor(CursorBase):
                 "Failed handling non-resultset; {0}".format(err))
 
         self._handle_warnings()
-        if self._connection.raise_on_warnings is True and self._warnings:
-            raise errors.get_mysql_exception(
-                self._warnings[0][1], self._warnings[0][2])
 
     def _handle_resultset(self):
         """Handles result set
@@ -773,9 +776,22 @@ class MySQLCursor(CursorBase):
         return None
 
     def _handle_warnings(self):
-        """Handle possible warnings after all results are consumed"""
+        """Handle possible warnings after all results are consumed
+
+        Also raises exceptions if raise_on_warnings is set
+        """
         if self._connection.get_warnings is True and self._warning_count:
             self._warnings = self._fetch_warnings()
+            # should not happen given self._warning_count is set?
+            if not self._warnings:
+                return
+
+            warning = errors.get_mysql_exception(
+                self._warnings[0][1], self._warnings[0][2], warning=True)
+            if self._connection.raise_on_warnings:
+                raise warning
+            else:
+                warnings.warn(warning, stacklevel=4)
 
     def _handle_eof(self, eof):
         """Handle EOF packet"""
@@ -783,9 +799,6 @@ class MySQLCursor(CursorBase):
         self._nextrow = (None, None)
         self._warning_count = eof['warning_count']
         self._handle_warnings()
-        if self._connection.raise_on_warnings is True and self._warnings:
-            raise errors.get_mysql_exception(
-                self._warnings[0][1], self._warnings[0][2])
 
     def _fetch_row(self):
         """Returns the next row in the result set

--- a/lib/mysql/connector/errors.py
+++ b/lib/mysql/connector/errors.py
@@ -98,7 +98,7 @@ def custom_error_exception(error=None, exception=None):
 
     return _CUSTOM_ERROR_EXCEPTIONS
 
-def get_mysql_exception(errno, msg=None, sqlstate=None):
+def get_mysql_exception(errno, msg=None, sqlstate=None, warning=False):
     """Get the exception matching the MySQL error
 
     This function will return an exception based on the SQLState. The given
@@ -124,7 +124,11 @@ def get_mysql_exception(errno, msg=None, sqlstate=None):
         pass
 
     if not sqlstate:
-        return DatabaseError(msg=msg, errno=errno)
+        if warning:
+            # match order of Warning arguments with Error
+            return Warning(errno, msg)
+        else:
+            return DatabaseError(msg=msg, errno=errno)
 
     try:
         return _SQLSTATE_CLASS_EXCEPTION[sqlstate[0:2]](
@@ -206,7 +210,7 @@ class Error(Exception):
         return self._full_msg
 
 
-class Warning(Exception):  # pylint: disable=W0622
+class Warning(Warning, Exception):  # pylint: disable=W0622
     """Exception for important warnings"""
     pass
 


### PR DESCRIPTION
Dear mysql connector team,

Here are some improvements to the way warnings work in the library, for your consideration, as well as a couple of `close()`-handling ones. (Apologies for that not being a separate commit due to time constraints.)

1. _Warnings now propagated using warnings module when `get_warnings` is set
  (`raise_on_warnings` behaves the same as before)_  
This I think might be useful since warnings are immediately visible, especially during development.
2. _Do not disable get_warnings if raise\_on\_warnings is explicitly set to False_  
Given (1) I think this makes sense
3. _`errors.Warning` subclasses `Warning`_  
Prerequisite for (1)
4._`errors.get\_mysql\_exception` can now return warnings where appropriate_  
Prerequisite for (1)
5. _cursor_[cext].handle_warnings now also emits warnings, not just exceptions_  
Prerequisite for (1)
6. _Ignore "unread result" exception in `cursor[_cext].close()`_  
If one e.g. calls `cursor.execute(...)` (unbuffered) and during looping over the result set an sql-unrelated exception occurs, during `cursor.close()` (e.g. via `finally` clause) the original exception will be override by the "unread result" one. I think it might make more sense to silence this exception when closing the cursor.
7. _`connection.close()` does not leak socket if `cmd_quit` fails_  
2nd statement in try-except closes socket, but might not be reached if `cmd_quit` fails first. Have each in their own try-except instead.