### PR TITLE
Improve binary value handling in queries (Python 3)

### DIFF
--- a/lib/mysql/connector/conversion.py
+++ b/lib/mysql/connector/conversion.py
@@ -169,6 +169,8 @@ class MySQLConverter(MySQLConverterBase):
                 return str(buf).encode('ascii')
         elif isinstance(buf, type(None)):
             return bytearray(b"NULL")
+        elif not PY2 and isinstance(buf, (bytes, bytearray)):
+            return bytearray(b"_binary'" + buf + b"'")
         else:
             return bytearray(b"'" + buf + b"'")
 

--- a/src/mysql_capi.c
+++ b/src/mysql_capi.c
@@ -1778,7 +1778,7 @@ MySQL_convert_to_mysql(MySQL *self, PyObject *args)
         }
         else if (PyBytes_Check(new_value))
         {
-            quoted= PyBytes_FromFormat("'%s'", PyBytes_AsString(new_value));
+            quoted= PyBytes_FromFormat("_binary'%s'", PyBytes_AsString(new_value));
             PyTuple_SET_ITEM(prepared, i, quoted);
 #endif
         }


### PR DESCRIPTION
To write raw binary values to e.g. a `BINARY` or `BLOB` column, one has to currently e.g. produce a hexadecimal representation to make sure MySQL **always** (and not just when the binary data is e.g. ASCII) interprets the input correctly:
```python
raw_data = b'somebinarygoeshere'
cursor.exectute('INSERT INTO somewhere VALUES (UNHEX(%s))', (binascii.b2a_hex(raw_data),)
```

With the proposed change (only applicable to Python 3):
```python
cursor.exectute('INSERT INTO somewhere VALUES (%s)', (raw_data,))
```

This is done by prepending the `_binary` prefix, see e.g. [here](http://dev.mysql.com/doc/refman/5.5/en/charset-literal.html) and [here](https://github.com/go-sql-driver/mysql/pull/382).

For Python 2, `bytearray` could be handled in a similar fashion but I wasn't sure how to best implement this in the C extension given it only deals with `bytes` and not `bytearray` currently, unlike the pure-Python version (where one could simply always prepend `_binary` if `buf` is bytearray (in `conversion.py`).