### PR TITLE
fix microsecond conversion from MySQL DATETIME to Python datetime

### DIFF
--- a/src/mysql_capi_conversion.c
+++ b/src/mysql_capi_conversion.c
@@ -441,7 +441,7 @@ mytopy_datetime(const char *data, const unsigned long length)
     if (data != end && end - data >= 2 && *data == '.')
     {
         // Fractional part
-        int field_length= 6;   // max fractional - 1
+        int field_length= 5;
         data++;
         value= (unsigned int)(*data - '0');
         while (data++ != end && isdigit(*data))
@@ -449,6 +449,13 @@ mytopy_datetime(const char *data, const unsigned long length)
             if (field_length-- > 0)
             {
                 value= (value * 10) + (unsigned int)(*data - '0');
+            }
+        }
+        if (field_length >= 0)
+        {
+            while (field_length-- > 0)
+            {
+                value*= 10;
             }
         }
         parts[6]= value;


### PR DESCRIPTION
The logic to convert microseconds in `mytopy_datetime` does not work properly (i.e. MySQL to Python conversion when using C extension). E.g. a value of `2016-10-20 15:40:23.8` from MySQL results in a `datetime.datetime(2016, 10, 20, 15, 40, 23, 8)`.
The correct value should be: `datetime.datetime(2016, 10, 20, 15, 40, 23, 800000)`.

This change uses the logic in `mytopy_time` to address this issue.