### PR TITLE
Bugfix for incorrect Django introspection type.

### DIFF
--- a/lib/mysql/connector/django/introspection.py
+++ b/lib/mysql/connector/django/introspection.py
@@ -279,9 +279,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                     'unique': False,
                     'index': False,
                     'check': False,
-                    'foreign_key': (
-                        (ref_table, ref_column) if ref_column else None,
-                    )
+                    'foreign_key': (ref_table, ref_column) if ref_column else None,
                 }
             constraints[constraint]['columns'].add(column)
         # Now get the constraint types


### PR DESCRIPTION
- Remove extra encapsulation from get_constraints for foreign key
  parameter which is stored as a constraint properties due to a
  incorrect detection type from a unique key as a foreign key when
  altering a OneToOneField in a Django migration.