### PR TITLE
Support for building wheels on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ cpy_server*/
 *_output.txt
 tests_*.log
 dev*.py
-src/mysqlxpb/mysqlx/mysqlx*
-
+*egg-info
+src/mysqlxpb*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get install -y \
+  g++-4.8 \
+  gcc-4.8 \
+  git \
+  python2.7 python2.7-dev python-pip \
+  libmysqlclient-dev libprotobuf-dev protobuf-compiler
+RUN pip install -U pip \
+ && pip install virtualenv
+
+WORKDIR /app
+CMD MYSQLXPB_PROTOBUF_INCLUDE_DIR=/usr/include/google/protobuf MYSQLXPB_PROTOBUF_LIB_DIR=/usr/local/lib/python3.6/site-packages/google/protobuf MYSQLXPB_PROTOC=/usr/bin/protoc python setup.py bdist_wheel --with-mysql-capi=$(which mysql_config)

--- a/build-wheel.sh
+++ b/build-wheel.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build -t asaha/mysql-connector-python-builder .
+docker run -v `pwd`:/app asaha/mysql-connector-python-builder

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ To install MySQL Connector/Python:
 
 """
 
-from distutils.core import setup
+from setuptools import setup, dist
 from distutils.command.install import INSTALL_SCHEMES
 
 # Make sure that data files are actually installed in the package directory

--- a/setupinfo.py
+++ b/setupinfo.py
@@ -21,12 +21,13 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-from distutils.core import Extension
+from setuptools import Extension
 import os
 import sys
 
 from lib.cpy_distutils import (
-    Install, InstallLib, BuildExtDynamic, BuildExtStatic
+    Install, InstallLib, BuildExtDynamic, BuildExtStatic,
+    BDistWheel,
 )
 
 # Development Status Trove Classifiers significant for Connector/Python
@@ -54,6 +55,7 @@ command_classes = {
     'build_ext_static': BuildExtStatic,
     'install_lib': InstallLib,
     'install': Install,
+    'bdist_wheel': BDistWheel,
 }
 
 package_dir = {'': 'lib'}


### PR DESCRIPTION
Adds a `bdist_wheel` command to enable building wheels. This means, I needed to switch to using `setuptools`.