### PR TITLE
mysql - Fix field names type (extension)

### DIFF
--- a/src/mysql_capi.c
+++ b/src/mysql_capi.c
@@ -220,32 +220,32 @@ fetch_fields(MYSQL_RES *result, unsigned int num_fields, MY_CHARSET_INFO *cs,
         field = PyTuple_New(11);
 
         decoded= mytopy_string(myfs[i].catalog, myfs[i].catalog_length,
-                               myfs[i].flags, charset, use_unicode);
+                               0, charset, use_unicode);
         if (NULL == decoded) return NULL; // decode error
         PyTuple_SET_ITEM(field, 0, decoded);
 
         decoded= mytopy_string(myfs[i].db, myfs[i].db_length,
-                               myfs[i].flags, charset, use_unicode);
+                               0, charset, use_unicode);
         if (NULL == decoded) return NULL; // decode error
         PyTuple_SET_ITEM(field, 1, decoded);
 
         decoded= mytopy_string(myfs[i].table, myfs[i].table_length,
-                               myfs[i].flags, charset, use_unicode);
+                               0, charset, use_unicode);
         if (NULL == decoded) return NULL; // decode error
         PyTuple_SET_ITEM(field, 2, decoded);
 
         decoded= mytopy_string(myfs[i].org_table, myfs[i].org_table_length,
-                               myfs[i].flags, charset, use_unicode);
+                               0, charset, use_unicode);
         if (NULL == decoded) return NULL; // decode error
         PyTuple_SET_ITEM(field, 3, decoded);
 
         decoded= mytopy_string(myfs[i].name, myfs[i].name_length,
-                               myfs[i].flags, charset, use_unicode);
+                               0, charset, use_unicode);
         if (NULL == decoded) return NULL; // decode error
         PyTuple_SET_ITEM(field, 4, decoded);
 
         decoded= mytopy_string(myfs[i].org_name, myfs[i].org_name_length,
-                               myfs[i].flags, charset, use_unicode);
+                               0, charset, use_unicode);
         if (NULL == decoded) return NULL; // decode error
         PyTuple_SET_ITEM(field, 5, decoded);
 


### PR DESCRIPTION
Field names were previously returned as bytes if field type is binary (when using extension). This meant different behaviour depending on whether using C extension or not.
```sql
SELECT 'string' AS 'col1', CAST('binary' AS BINARY) AS 'col2'
```
For the above query with a dict cursor, the pure version would return:
```python
[{'col1': 'string', 'col2': bytearray(b'binary')}]
```
.. whereas the C extension-enabled one:
```python
[{'col1': 'string', b'col2': b'binary'}]
```
Note how `col2` field name is `bytes` in the 2nd return.

As far as I understand, metadata fields including field name (and also e.g. table & db names) should not take the binary flag into account since that applies to the value of the field only. (By leaving the `use_unicode` option in, using a charset of `binary` still allows for *all* field names to be returned as `bytes` instances.)