### PR TITLE
Introduce SSL option 'verify_identity'

### DIFF
--- a/lib/mysql/connector/connection.py
+++ b/lib/mysql/connector/connection.py
@@ -147,6 +147,7 @@ class MySQLConnection(MySQLConnectionAbstract):
                                        ssl_options.get('cert'),
                                        ssl_options.get('key'),
                                        ssl_options.get('verify_cert') or False,
+                                       ssl_options.get('verify_identity') or False,
                                        ssl_options.get('cipher'))
             self._ssl_active = True
 

--- a/lib/mysql/connector/constants.py
+++ b/lib/mysql/connector/constants.py
@@ -56,6 +56,7 @@ DEFAULT_CONFIGURATION = {
     'ssl_cert': None,
     'ssl_key': None,
     'ssl_verify_cert': False,
+    'ssl_verify_identity': False,
     'ssl_cipher': None,
     'ssl_disabled': False,
     'passwd': None,


### PR DESCRIPTION
In order to allow clients to verify the server name against a server
certificate, this patch adds an option 'ssl_verify_identity' to
mysql.connector that calls ssl.match_hostname(...) internally.

The option is disabled by default, so the old behaviour is unchanged.
Client code must enable the option explicitly.