### PR TITLE
Reduce callproc roundtrip time

### DIFF
--- a/lib/mysql/connector/cursor.py
+++ b/lib/mysql/connector/cursor.py
@@ -739,16 +739,23 @@ class MySQLCursor(CursorBase):
             argnames = []
             argtypes = []
             if args:
+                argvalues = []
                 for idx, arg in enumerate(args):
                     argname = argfmt.format(name=procname, index=idx + 1)
                     argnames.append(argname)
                     if isinstance(arg, tuple):
                         argtypes.append(" CAST({0} AS {1})".format(argname,
                                                                    arg[1]))
-                        self.execute("SET {0}=%s".format(argname), (arg[0],))
+                        argvalues.append(arg[0])
                     else:
                         argtypes.append(argname)
-                        self.execute("SET {0}=%s".format(argname), (arg,))
+                        argvalues.append(arg)
+
+                self.execute(
+                    "SET %s" % ','.join('{0}=%s'.format(arg)
+                                        for arg in argnames),
+                    argvalues
+                )
 
             call = "CALL {0}({1})".format(procname, ','.join(argnames))
 

--- a/lib/mysql/connector/cursor_cext.py
+++ b/lib/mysql/connector/cursor_cext.py
@@ -415,16 +415,23 @@ class CMySQLCursor(MySQLCursorAbstract):
             argnames = []
             argtypes = []
             if args:
+                argvalues = []
                 for idx, arg in enumerate(args):
                     argname = argfmt.format(name=procname, index=idx + 1)
                     argnames.append(argname)
                     if isinstance(arg, tuple):
                         argtypes.append(" CAST({0} AS {1})".format(argname,
                                                                    arg[1]))
-                        self.execute("SET {0}=%s".format(argname), (arg[0],))
+                        argvalues.append(arg[0])
                     else:
                         argtypes.append(argname)
-                        self.execute("SET {0}=%s".format(argname), (arg,))
+                        argvalues.append(arg)
+
+                self.execute(
+                    "SET %s" % ','.join('{0}=%s'.format(arg)
+                                        for arg in argnames),
+                    argvalues
+                )
 
             call = "CALL {0}({1})".format(procname, ','.join(argnames))
 


### PR DESCRIPTION
The cursor (both pure and extension versions) uses a single `SELECT` query to retrieve procedure result parameters after a procedure call (as part of `callproc`). However, to set the input parameters, one `SET` call is used per parameter. For any procedures with more than one parameter this results in more queries than necessary and ultimately the `callproc` call takes longer.

With this patch just a single ` SET` call is made.