### PR TITLE
Fix AttributeError on datetime with the Django Connector

### DIFF
--- a/lib/mysql/connector/django/base.py
+++ b/lib/mysql/connector/django/base.py
@@ -114,6 +114,9 @@ class DjangoMySQLConverter(MySQLConverter):
 
         Returns datetime.datetime()
         """
+        if isinstance(value, datetime):
+            return value
+
         if not value:
             return None
         dt = MySQLConverter._DATETIME_to_python(self, value)
@@ -151,6 +154,9 @@ class DjangoCMySQLConverter(MySQLConverterBase):
 
         Returns datetime.datetime()
         """
+        if isinstance(value, datetime):
+            return value
+
         if not value:
             return None
         if settings.USE_TZ and timezone.is_naive(value):


### PR DESCRIPTION
In some case, especially when migrating with a very old project from Python-MySQLdb to python-mysql-connector, the Django{C}MysqlConverter class receives a `datetime` as a value instead a `str`.

The fix simply check if we have a `datetime` as a value and if so, return it. 