### PR TITLE
C extension - fix reference leaks when converting int/long/float (to mysql)

### DIFF
--- a/src/mysql_capi.c
+++ b/src/mysql_capi.c
@@ -1751,10 +1751,12 @@ MySQL_convert_to_mysql(MySQL *self, PyObject *args)
         if (PyIntLong_Check(value) || PyFloat_Check(value))
         {
 #ifdef PY3
+            new_value = PyObject_Str(value);
             PyTuple_SET_ITEM(prepared, i,
                              PyBytes_FromString(
                                 (const char *)PyUnicode_1BYTE_DATA(
-                                PyObject_Str(value))));
+                                new_value)));
+            Py_CLEAR(new_value);
 #else
             numeric= PyObject_Repr(value);
             tmp= PyString_AsString(numeric);
@@ -1764,6 +1766,7 @@ MySQL_convert_to_mysql(MySQL *self, PyObject *args)
                 new_num= PyString_FromStringAndSize(tmp, tmp_size);
                 _PyString_Resize(&new_num, tmp_size - 1);
                 PyTuple_SET_ITEM(prepared, i, new_num);
+                Py_CLEAR(numeric);
             }
             else
             {


### PR DESCRIPTION
When using the C extension (`use_pure = False`), query argument preparation results in reference leaks (via `MySQL_convert_to_mysql`):
- Python 3: **All** `int` and `float` arguments, via `PyObject_Str`
- Python 2: **All** `long` arguments (i.e. whenever `repr()` thereof ends with an "L"), via `PyObject_Repr` (when `numeric` is not added to tuple)

**Note**: There are additional shortcomings in said function which are not addressed by this patch:
- Multiple API calls are not checked for failure/exception, for example:
    - [PyTuple_New](https://github.com/mysql/mysql-connector-python/blob/fba053fc3da88526d9e4b5487002d4c89fbbc529/src/mysql_capi.c#L1734)
    - [PyObject_Str](https://github.com/mysql/mysql-connector-python/blob/fba053fc3da88526d9e4b5487002d4c89fbbc529/src/mysql_capi.c#L1757)
    - [PyObject_Repr](https://github.com/mysql/mysql-connector-python/blob/fba053fc3da88526d9e4b5487002d4c89fbbc529/src/mysql_capi.c#L1759)
   - [PyString_FromStringAndSize](https://github.com/mysql/mysql-connector-python/blob/fba053fc3da88526d9e4b5487002d4c89fbbc529/src/mysql_capi.c#L1764)
- Potentially unnecessary [string resize](https://github.com/mysql/mysql-connector-python/blob/fba053fc3da88526d9e4b5487002d4c89fbbc529/src/mysql_capi.c#L1764-L1765) - can't it just be created one byte shorter?