### PR TITLE
Fix multiple reference leaks

### DIFF
--- a/src/exceptions.c
+++ b/src/exceptions.c
@@ -90,9 +90,9 @@ raise_with_session(MYSQL *conn, PyObject *exc_type)
         goto ERR;
     }
 
-    PyObject_SetAttr(err_object, PyString_FromString("sqlstate"), sqlstate);
-    PyObject_SetAttr(err_object, PyString_FromString("errno"), error_no);
-    PyObject_SetAttr(err_object, PyString_FromString("msg"), error_msg);
+    PyObject_SetAttrString(err_object, "sqlstate", sqlstate);
+    PyObject_SetAttrString(err_object, "errno", error_no);
+    PyObject_SetAttrString(err_object, "msg", error_msg);
 
     PyErr_SetObject(exc_type, err_object);
     goto CLEANUP;
@@ -156,9 +156,9 @@ raise_with_stmt(MYSQL_STMT *stmt, PyObject *exc_type)
         goto ERR;
     }
 
-    PyObject_SetAttr(err_object, PyString_FromString("sqlstate"), sqlstate);
-    PyObject_SetAttr(err_object, PyString_FromString("errno"), error_no);
-    PyObject_SetAttr(err_object, PyString_FromString("msg"), error_msg);
+    PyObject_SetAttrString(err_object, "sqlstate", sqlstate);
+    PyObject_SetAttrString(err_object, "errno", error_no);
+    PyObject_SetAttrString(err_object, "msg", error_msg);
 
     PyErr_SetObject(exc_type, err_object);
     goto CLEANUP;
@@ -202,9 +202,9 @@ raise_with_string(PyObject *error_msg, PyObject *exc_type)
 	{
         goto ERR;
     }
-    PyObject_SetAttr(err_object, PyString_FromString("sqlstate"), Py_None);
-    PyObject_SetAttr(err_object, PyString_FromString("errno"), error_no);
-    PyObject_SetAttr(err_object, PyString_FromString("msg"), error_msg);
+    PyObject_SetAttrString(err_object, "sqlstate", Py_None);
+    PyObject_SetAttrString(err_object, "errno", error_no);
+    PyObject_SetAttrString(err_object, "msg", error_msg);
 
     PyErr_SetObject(exc_type, err_object);
     goto CLEANUP;


### PR DESCRIPTION
After additional testing (of https://github.com/mysql/mysql-connector-python/pull/41), I found more reference leaks / unnecessary increments:
- exception attribute names (3x string)
- True, False & None reference count increases
- Removed redundant code & comment from MySQL_connected
- MySQL_init & MySQL_connect leaks (charset)

See [this gist](https://gist.github.com/vtermanis/199619111521db585d1bc9f451b59af3) for script used to track the leaks, together with before/after output.

**Note**: There might well be more leaks in the functions I have examined as well as in the module itself. It would be nice if an internal review could be performed on the C extension as otherwise long-running Python processes utilising this library can leak a significant amount of memory.