### PR TITLE
Fix decoding of binary collations for non-binary character sets

### DIFF
--- a/lib/mysql/connector/connection_cext.py
+++ b/lib/mysql/connector/connection_cext.py
@@ -341,7 +341,8 @@ class CMySQLConnection(MySQLConnectionAbstract):
                 None,
                 None,
                 ~int(col[9]) & FieldFlag.NOT_NULL,
-                int(col[9])
+                int(col[9]),
+                int(col[6])
             ))
 
         return {

--- a/lib/mysql/connector/conversion.py
+++ b/lib/mysql/connector/conversion.py
@@ -591,7 +591,7 @@ class MySQLConverter(MySQLConverterBase):
             # Check if we deal with a SET
             if dsc[7] & FieldFlag.SET:
                 return self._SET_to_python(value, dsc)
-            if dsc[7] & FieldFlag.BINARY:
+            if dsc[8] == 63:
                 if self.charset != 'binary':
                     try:
                         return value.decode(self.charset)
@@ -613,7 +613,8 @@ class MySQLConverter(MySQLConverterBase):
             # Check if we deal with a SET
             if dsc[7] & FieldFlag.SET:
                 return self._SET_to_python(value, dsc)
-            if dsc[7] & FieldFlag.BINARY:
+            # Binary field character set
+            if dsc[8] == 63:
                 if self.charset != 'binary':
                     try:
                         return value.decode(self.charset)
@@ -634,7 +635,7 @@ class MySQLConverter(MySQLConverterBase):
     def _BLOB_to_python(self, value, dsc=None):  # pylint: disable=C0103
         """Convert BLOB data type to Python"""
         if dsc is not None:
-            if dsc[7] & FieldFlag.BINARY:
+            if dsc[8] == 63:
                 if PY2:
                     return value
                 return bytes(value)

--- a/lib/mysql/connector/protocol.py
+++ b/lib/mysql/connector/protocol.py
@@ -250,7 +250,7 @@ class MySQLProtocol(object):
         (packet, _) = utils.read_lc_string(packet)  # org_name
 
         try:
-            (_, _, field_type,
+            (charset_id, _, field_type,
              flags, _) = struct_unpack('<xHIBHBxx', packet)
         except struct.error:
             raise errors.InterfaceError("Failed parsing column information")
@@ -264,6 +264,7 @@ class MySQLProtocol(object):
             None,  # scale
             ~flags & FieldFlag.NOT_NULL,  # null_ok
             flags,  # MySQL specific
+            charset_id,  # field character set
         )
 
     def parse_eof(self, packet):

--- a/src/include/mysql_capi_conversion.h
+++ b/src/include/mysql_capi_conversion.h
@@ -71,7 +71,7 @@ mytopy_bit(const char *data, const unsigned long length);
 
 PyObject*
 mytopy_string(const char *data, const unsigned long length,
-              const unsigned long flags, const char *charset,
+              const unsigned long charset_id, const char *charset_out,
               unsigned int use_unicode);
 
 #endif /* MYCONNPY_MYSQL_CAPI_CONVERSION_H */

--- a/src/mysql_capi.c
+++ b/src/mysql_capi.c
@@ -2316,7 +2316,7 @@ MySQL_fetch_row(MySQL *self)
 	unsigned long *field_lengths;
 	unsigned int num_fields;
 	unsigned int i;
-	unsigned long field_type, field_flags;
+	unsigned long field_type, field_flags, field_charset_id;
 	const char *charset= NULL;
 
     CHECK_SESSION(self);
@@ -2393,6 +2393,7 @@ MySQL_fetch_row(MySQL *self)
 
         field_type= PyLong_AsUnsignedLong(PyTuple_GetItem(field_info, 8));
         field_flags= PyLong_AsUnsignedLong(PyTuple_GetItem(field_info, 9));
+        field_charset_id= PyLong_AsUnsignedLong(PyTuple_GetItem(field_info, 6));
 
         // Convert MySQL values to Python objects
         if (field_type == MYSQL_TYPE_TINY ||
@@ -2424,7 +2425,7 @@ MySQL_fetch_row(MySQL *self)
                  field_type == MYSQL_TYPE_ENUM ||
                  field_type == MYSQL_TYPE_VAR_STRING)
         {
-            value= mytopy_string(row[i], field_lengths[i], field_flags,
+            value= mytopy_string(row[i], field_lengths[i], field_charset_id,
                                   charset, self->use_unicode);
             if (!value)
             {
@@ -2487,7 +2488,7 @@ MySQL_fetch_row(MySQL *self)
         }
         else if (field_type == MYSQL_TYPE_BLOB)
         {
-            value= mytopy_string(row[i], field_lengths[i], field_flags,
+            value= mytopy_string(row[i], field_lengths[i], field_charset_id,
                                   charset, self->use_unicode);
             PyTuple_SET_ITEM(result_row, i, value);
         }
@@ -2500,7 +2501,7 @@ MySQL_fetch_row(MySQL *self)
     	else
     	{
     	    // Do our best to convert whatever we got from MySQL to a str/bytes
-            value = mytopy_string(row[i], field_lengths[i], field_flags,
+            value = mytopy_string(row[i], field_lengths[i], field_charset_id,
                                   charset, self->use_unicode);
     		PyTuple_SET_ITEM(result_row, i, value);
     	}

--- a/src/mysql_capi_conversion.c
+++ b/src/mysql_capi_conversion.c
@@ -729,25 +729,25 @@ pytomy_decimal(PyObject *obj)
 
   @param    data        string to be converted
   @param    length      length of data
-  @param    flags       field flags
-  @param    charset     character used for decoding
+  @param    charset_id  character set of field
+  @param    charset_out character used for decoding
   @param    use_unicode return Unicode
 
   @return   Converted string
-    @retval PyUnicode   if not BINARY_FLAG
+    @retval PyUnicode   if binary charset_id
     @retval PyBytes     Python v3 if not use_unicode
     @retval PyString    Python v2 if not use_unicode
     @retval NULL    Exception
  */
 PyObject*
 mytopy_string(const char *data, const unsigned long length,
-              const unsigned long flags, const char *charset,
+              const unsigned long charset_id, const char *charset_out,
               unsigned int use_unicode)
 {
-    if (!charset || !data) {
+    if (!charset_out || !data) {
         printf("\n==> here ");
-        if (charset) {
-            printf(" charset:%s", charset);
+        if (charset_out) {
+            printf(" charset:%s", charset_out);
         }
         if (data) {
             printf(" data:'%s'", data);
@@ -756,9 +756,10 @@ mytopy_string(const char *data, const unsigned long length,
         return NULL;
     }
 
-    if (!(flags & BINARY_FLAG) && use_unicode && strcmp(charset, "binary") != 0)
+    // 63 designates binary character set for field
+    if (63 != charset_id && use_unicode && strcmp(charset_out, "binary") != 0)
     {
-        return PyUnicode_Decode(data, length, charset, NULL);
+        return PyUnicode_Decode(data, length, charset_out, NULL);
     }
     else
     {


### PR DESCRIPTION
## Summary
Currently this library uses `FieldFlag.BINARY` / `BINARY_FLAG` to decide whether to decode a field or to leave it as raw bytes (when said flag is set). However, this appears to be incorrect behaviour. 

The C API documentation [states](https://dev.mysql.com/doc/refman/8.0/en/c-api-data-structures.html):
> To distinguish between binary and nonbinary data for string data types, check whether the charsetnr value is 63. If so, the character set is binary, which indicates binary rather than nonbinary data.

And the BINARY/VARBINARY section also [confirms this](https://dev.mysql.com/doc/refman/8.0/en/binary-varbinary.html):
> [...] the BINARY attribute does not cause the column to be treated as a binary string column. Instead, it causes the binary (_bin) collation for the column character set to be used, and the column itself contains non-binary character strings rather than binary byte strings.

## Example
(Used Python 3.5.2)
```python
# Assuming utf8mb4 connection (same behaviour for utf8 with equivalent collations)
cursor.execute(
    '''SELECT
    CAST(%s AS CHAR) COLLATE utf8mb4_bin,
    CAST(%s AS CHAR) COLLATE utf8mb4_unicode_ci,
    BINARY %s
    ''',
    ('abc',) * 3
)
print(cursor.fetchall())
```
Actual results:
```python
[(bytearray(b'abc'), 'abc', bytearray(b'abc'))]  # pure
[(b'abc', 'abc', b'abc')]  # ext
```
Expected results:
```python
[('abc', 'abc', bytearray(b'abc'))]  # pure
[('abc', 'abc', b'abc')]  # ext
```
## Notes
- This might be the same bug as already reported in [#70543](https://bugs.mysql.com/bug.php?id=70543)
- Other MySQL client libraries such as [MySQLdb](https://github.com/PyMySQL/mysqlclient-python) and [PyMySQL](https://github.com/PyMySQL/PyMySQL) have the correct decoding behaviour
- I have **not** updated the test cases. Because the `description` field has been expanded to include an additional entry (the field character set id) and the `BINARY` flag is no longer used for decoding logic, some test cases now most likely fail.
