### PR TITLE
Return raw bytes or bytearray if decoding fails

### DIFF
--- a/lib/mysql/connector/conversion.py
+++ b/lib/mysql/connector/conversion.py
@@ -629,7 +629,10 @@ class MySQLConverter(MySQLConverterBase):
         if self.charset == 'binary':
             return value
         if isinstance(value, (bytes, bytearray)) and self.use_unicode:
-            return value.decode(self.charset)
+            try:
+                return value.decode(self.charset)
+            except UnicodeDecodeError:
+                return value
 
         return value
 


### PR DESCRIPTION
Decoding bytearrays can fail if the value is
binary data. Add a fallback and return the
raw value if the decode function throws a
UnicodeDecodeError.