### PR TITLE
Fixed load data infile file handle bug.

### DIFF
--- a/lib/mysql/connector/connection.py
+++ b/lib/mysql/connector/connection.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2018, 2019 Oracle and/or its affiliates. 
+# All rights reserved.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0, as

--- a/lib/mysql/connector/connection.py
+++ b/lib/mysql/connector/connection.py
@@ -399,6 +399,8 @@ class MySQLConnection(MySQLConnectionAbstract):
         """Handle a LOAD DATA INFILE LOCAL request"""
         try:
             data_file = open(filename, 'rb')
+            return self._handle_ok(self._send_data(data_file,
+                                               send_empty_packet=True))
         except IOError:
             # Send a empty packet to cancel the operation
             try:
@@ -408,9 +410,13 @@ class MySQLConnection(MySQLConnectionAbstract):
                     "MySQL Connection not available.")
             raise errors.InterfaceError(
                 "File '{0}' could not be read".format(filename))
+        finally:
+            try:
+                data_file.close()
+            except IOError, NameError:
+                # don't worry if the file was never opened
+                pass
 
-        return self._handle_ok(self._send_data(data_file,
-                                               send_empty_packet=True))
 
     def _handle_result(self, packet):
         """Handle a MySQL Result


### PR DESCRIPTION
-The file handle for that reads the local file for a load data local
infile command is never closed. This can cause issues if you are running
hundreds of load data commands as you run out of python IO handles.
-Fixed the bug by adding a finally clause to always close the files.