### PR TITLE
Add missing username connection argument for driver compatibility

### DIFF
--- a/lib/mysql/connector/abstracts.py
+++ b/lib/mysql/connector/abstracts.py
@@ -277,6 +277,7 @@ class MySQLConnectionAbstract(object):
             # (<other driver argument>,<translates to>)
             ('db', 'database'),
             ('passwd', 'password'),
+            ('username', 'user'),
             ('connect_timeout', 'connection_timeout'),
         ]
         for compat, translate in compat_map:


### PR DESCRIPTION
This PR adds `username` as a synonymous argument for `user` as a connection argument. This compatibility is listed in the documentation (https://dev.mysql.com/doc/connector-python/en/connector-python-connectargs.html), but appears to have been left out of the mapping translation.