### PR TITLE
Implement unread_result setter in CMySQLConnection

### DIFF
--- a/lib/mysql/connector/connection_cext.py
+++ b/lib/mysql/connector/connection_cext.py
@@ -514,6 +514,12 @@ class CMySQLConnection(MySQLConnectionAbstract):
     def unread_result(self):
         """Check if there are unread results or rows"""
         return self.result_set_available
+    
+    @unread_result.setter
+    def unread_result(self, value):
+        if not isinstance(value, bool):
+            raise ValueError("Expected a boolean type")
+        self._unread_result = value
 
     @property
     def more_results(self):


### PR DESCRIPTION
`CMySQLConnection` inherits from `MySQLConnectionAbstract`, which implements both the `unread_result` property _and_ the `unread_result` setter.

In python, if you inherit a property and a setter from a base class (in this case, `MySQLConnectionAbstract`), and then override the property, this _also overrides the setter_.  So then when other code tries to use the setter (e.g. [here](https://github.com/mysql/mysql-connector-python/blob/master/lib/mysql/connector/cursor.py#L835)), it fails.