### PR TITLE
Fix binary flag test in cext.

### DIFF
--- a/src/mysql_capi_conversion.c
+++ b/src/mysql_capi_conversion.c
@@ -752,7 +752,7 @@ mytopy_string(const char *data, const unsigned long length,
         return NULL;
     }
 
-    if (!((flags != 0) & flags & BINARY_FLAG) && use_unicode && strcmp(charset, "binary") != 0)
+    if (!(flags & BINARY_FLAG) && use_unicode && strcmp(charset, "binary") != 0)
     {
         return PyUnicode_Decode(data, length, charset, NULL);
     }


### PR DESCRIPTION
MySQL Connector 8.0.16 with cext tries to decode binary values as unicode strings because it fails to detect when a BINARY_FLAG is set on a MySQL value.

The old test `!((flags != NULL) & flags & BINARY_FLAG)` is always 1 (i.e. it assumes the field is not binary).

This fix also allows MySQL connector to work seamlessly with SQLAlchemy (without any unicode/binary conversion issues).