### PR TITLE
followup fix for BUG29855733, reserved filed should be with length 22 now

### DIFF
--- a/lib/mysql/connector/protocol.py
+++ b/lib/mysql/connector/protocol.py
@@ -141,7 +141,7 @@ class MySQLProtocol(object):
         return utils.int4store(client_flags) + \
                utils.int4store(max_allowed_packet) + \
                utils.int2store(charset) + \
-               b'\x00' * 23
+               b'\x00' * 22
 
     def make_command(self, command, argument=None):
         """Make a MySQL packet containing a command"""


### PR DESCRIPTION
After commit d4f740eac13b6ab0df7e6da9176642cf0d8cfda1, MySQL connector python driver is broken to connect with Azure MySQL server. From MySQL Protocol::SSLRequest: , and commit  d4f740eac13b6ab0df7e6da9176642cf0d8cfda1, the length of the reserved field should be 22 now.