### PR TITLE
Allow using modern features when connecting to MariaDB servers

### DIFF
--- a/lib/mysql/connector/abstracts.py
+++ b/lib/mysql/connector/abstracts.py
@@ -423,11 +423,17 @@ class MySQLConnectionAbstract(object):
             server_version = server_version.decode()
 
         # pylint: disable=W1401
-        regex_ver = re.compile(r"^(\d{1,2})\.(\d{1,2})\.(\d{1,3})(.*)")
+        regex_ver = re.compile(r"^5\.5\.5-(\d{1,2})\.(\d{1,2})\.(\d{1,2})")
         # pylint: enable=W1401
         match = regex_ver.match(server_version)
+
         if not match:
-            raise errors.InterfaceError("Failed parsing MySQL version")
+            # pylint: disable=W1401
+            regex_ver = re.compile(r"^(\d{1,2})\.(\d{1,2})\.(\d{1,3})(.*)")
+            # pylint: enable=W1401
+            match = regex_ver.match(server_version)
+            if not match:
+                raise errors.InterfaceError("Failed parsing MySQL version")
 
         version = tuple([int(v) for v in match.groups()[0:3]])
         if version < (4, 1):


### PR DESCRIPTION
MariaDB uses a "hack" to encode its version since it bumped it to 10.x: it reports 5.5.5-(a.b.c), being 5.5.5 a version not used by the original MySQL source and a.b.c the real server version. 

Since the connector only parses the first part of the version string, 5.5.5 is always incorrectly reported when connecting to MariaDB.

This patch attempts to detect this version string format and return the appropiate version tuple.

I noticed it after a fresh install of the connector from pypy. Just after calling ctx.close():

`Traceback (most recent call last):                                                                                                                                                             
  File "/usr/lib/python3.7/site-packages/mysql/connector/connection.py", line 811, in reset_session                                                                                            
    self.cmd_reset_connection()                                                                                                                                                                
  File "/usr/lib/python3.7/site-packages/mysql/connector/connection.py", line 1158, in cmd_reset_connection                                                                                    
    raise errors.NotSupportedError("MySQL version 5.7.2 and "                                                                                                                                  
mysql.connector.errors.NotSupportedError: MySQL version 5.7.2 and earlier does not support COM_RESET_CONNECTION. `

I am not sure this is the best approach, to be honest, or whether it could have more implications that I'm unaware of.