### PR TITLE
fix CMySQLCursor.fetchmany

### DIFF
--- a/lib/mysql/connector/cursor_cext.py
+++ b/lib/mysql/connector/cursor_cext.py
@@ -105,7 +105,7 @@ class CMySQLCursor(MySQLCursorAbstract):
         When free is True (default) the result will be freed.
         """
         self._rowcount = -1
-        self._nextrow = (None, None)
+        self._nextrow = None
         self._affected_rows = -1
         self._insert_id = 0
         self._warning_count = 0


### PR DESCRIPTION
Issue: When calling fetchmany iteratively and reaching end of rows in cursor, fetchmany does not updates self. _nextrow if there is no unread_result (only happens when the last batch is not a full batch).
Fix: add an additional if/else where the self._nextrow is reset to (None, None) when unread_result is False.