### PR TITLE
Fix BUG96280

### DIFF
--- a/lib/mysql/connector/protocol.py
+++ b/lib/mysql/connector/protocol.py
@@ -475,14 +475,10 @@ class MySQLProtocol(object):
             elif field[1] == FieldType.TIME:
                 (packet, value) = self._parse_binary_time(packet, field)
                 values.append(value)
-            elif field[1] in (FieldType.BLOB, FieldType.TINY_BLOB,
-                              FieldType.MEDIUM_BLOB, FieldType.LONG_BLOB):
-                ## Fix
-                #  - BUG96280
-                (packet, value) = utils.read_lc_string(packet)
-                values.append(value)
             else:
                 (packet, value) = utils.read_lc_string(packet)
+                ## Fix
+                #  - BUG96280
                 try:
                     values.append(value.decode(charset))
                 except UnicodeDecodeError:

--- a/lib/mysql/connector/protocol.py
+++ b/lib/mysql/connector/protocol.py
@@ -475,9 +475,18 @@ class MySQLProtocol(object):
             elif field[1] == FieldType.TIME:
                 (packet, value) = self._parse_binary_time(packet, field)
                 values.append(value)
+            elif field[1] in (FieldType.BLOB, FieldType.TINY_BLOB,
+                              FieldType.MEDIUM_BLOB, FieldType.LONG_BLOB):
+                ## Fix
+                #  - BUG96280
+                (packet, value) = utils.read_lc_string(packet)
+                values.append(value)
             else:
                 (packet, value) = utils.read_lc_string(packet)
-                values.append(value.decode(charset))
+                try:
+                    values.append(value.decode(charset))
+                except UnicodeDecodeError:
+                    values.append(value)
 
         return tuple(values)
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -402,12 +402,16 @@ class MySQLProtocolTests(tests.MySQLConnectorTests):
                   ('aDate', 10, None, None, None, None, 1, 128),
                   ('aDateTime', 12, None, None, None, None, 1, 128),
                   ('aTime', 11, None, None, None, None, 1, 128),
-                  ('aNull', 6, None, None, None, None, 1, 128)]
+                  ('aNull', 6, None, None, None, None, 1, 128),
+                  ('aBlob', 252, None, None, None, None, 1, 144),
+                  ('aVarBinary', 253, None, None, None, None, 1, 128)]
 
         packet = bytearray(b'\x00\x01\x03\x61\x62\x63\x04\x33\x2e\x31\x34\x08'
                            b'\x2d\x33\x2e\x31\x34\x31\x35\x39\x04\xd3\x07'
                            b'\x01\x1f\x07\xb9\x07\x06\x0e\x15\x21\x0e\x0c'
-                           b'\x00\x0a\x00\x00\x00\x10\x0f\x1e\x70\x82\x03\x00')
+                           b'\x00\x0a\x00\x00\x00\x10\x0f\x1e\x70\x82\x03\x00'
+                           b'\x05\xaa\xbb\xcc\xdd\xff'
+                           b'\x05\xaa\xbb\xcc\xdd\xff')
 
         # float/double are returned as DECIMAL by MySQL
         exp = ('abc',
@@ -416,7 +420,9 @@ class MySQLProtocolTests(tests.MySQLConnectorTests):
                datetime.date(2003, 1, 31),
                datetime.datetime(1977, 6, 14, 21, 33, 14),
                datetime.timedelta(10, 58530, 230000),
-               None)
+               None,
+               bytearray(b'\xaa\xbb\xcc\xdd\xff'),
+               bytearray(b'\xaa\xbb\xcc\xdd\xff'))
         res = self._protocol._parse_binary_values(fields, packet)
         self.assertEqual(exp, res)
 


### PR DESCRIPTION
 This PR fix [BUG96280](https://bugs.mysql.com/bug.php?id=96280): When fetching binary result (include BLOB, VARBINARY data type) from a prepared cursor, UnicodeDecodeError has occurred.

## What’s change?
- Add a checking for blob data type and return the bytearray.
- Add a fallback and return the bytearray value if the UnicodeDecodeError occur.
- Add unit test for above changes.