### PR TITLE
implement context manager

### DIFF
--- a/lib/mysql/connector/abstracts.py
+++ b/lib/mysql/connector/abstracts.py
@@ -1225,3 +1225,11 @@ class MySQLCursorAbstract(object):
     def fetchwarnings(self):
         """Returns Warnings."""
         return self._warnings
+
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()


### PR DESCRIPTION
when i make mysql migration
 i found class cursor is not implement context manager
Difference with pymysql
and [i found not just me would like to have context manager at cursor](https://bugs.mysql.com/bug.php?id=89113)

therefore i implement context manager at cursor base 
and i had test it after i finish it , it work

i hope you can merged it or Improve this demand
if not please tell me what do you think
thanks a lot

by mysql Lovers