### PR TITLE
Django 3.x removes six from django.utils. Removing unused imports.

### DIFF
--- a/lib/mysql/connector/django/base.py
+++ b/lib/mysql/connector/django/base.py
@@ -21,7 +21,7 @@ from datetime import datetime
 import sys
 import warnings
 
-import django
+import six
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import cached_property
 
@@ -52,10 +52,9 @@ if version < (1, 11):
         "is required; you have %s" % mysql.connector.__version__)
 
 from django.db import utils
-from django.db.backends import utils as backend_utils
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.signals import connection_created
-from django.utils import (six, timezone, dateparse)
+from django.utils import (timezone, dateparse)
 from django.conf import settings
 
 from mysql.connector.django.client import DatabaseClient

--- a/lib/mysql/connector/django/client.py
+++ b/lib/mysql/connector/django/client.py
@@ -1,6 +1,5 @@
 # MySQL Connector/Python - MySQL driver written in Python.
 
-import django
 import subprocess
 
 from django.db.backends.base.client import BaseDatabaseClient

--- a/lib/mysql/connector/django/compiler.py
+++ b/lib/mysql/connector/django/compiler.py
@@ -1,9 +1,8 @@
 # MySQL Connector/Python - MySQL driver written in Python.
 
 
-import django
 from django.db.models.sql import compiler
-from django.utils.six.moves import zip_longest
+from six.moves import zip_longest
 
 
 class SQLCompiler(compiler.SQLCompiler):

--- a/lib/mysql/connector/django/creation.py
+++ b/lib/mysql/connector/django/creation.py
@@ -1,6 +1,5 @@
 # MySQL Connector/Python - MySQL driver written in Python.
 
-import django
 from django.db import models
 
 from django.db.backends.base.creation import BaseDatabaseCreation

--- a/lib/mysql/connector/django/features.py
+++ b/lib/mysql/connector/django/features.py
@@ -1,9 +1,7 @@
 # MySQL Connector/Python - MySQL driver written in Python.
 
-import django
 from django.db.backends.base.features import BaseDatabaseFeatures
 from django.utils.functional import cached_property
-from django.utils import six
 
 try:
     import pytz

--- a/lib/mysql/connector/django/introspection.py
+++ b/lib/mysql/connector/django/introspection.py
@@ -4,7 +4,6 @@
 import re
 from collections import namedtuple
 
-import django
 from django.db.backends.base.introspection import (
     BaseDatabaseIntrospection, FieldInfo, TableInfo
 )

--- a/lib/mysql/connector/django/operations.py
+++ b/lib/mysql/connector/django/operations.py
@@ -4,10 +4,9 @@ from __future__ import unicode_literals
 
 import uuid
 
-import django
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
-from django.utils import six, timezone
+from django.utils import timezone
 from django.utils.encoding import force_text
 
 try:

--- a/lib/mysql/connector/django/schema.py
+++ b/lib/mysql/connector/django/schema.py
@@ -1,6 +1,5 @@
 # MySQL Connector/Python - MySQL driver written in Python.
 
-import django
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.models import NOT_PROVIDED
 

--- a/lib/mysql/connector/django/validation.py
+++ b/lib/mysql/connector/django/validation.py
@@ -1,7 +1,5 @@
 # MySQL Connector/Python - MySQL driver written in Python.
 
-import django
-
 from django.db.backends.base.validation import BaseDatabaseValidation
 from django.core import checks
 from django.db import connection


### PR DESCRIPTION
Fixing mysql-connector-python to support Django 3 as it removes six from django.utils.