### PR TITLE
Bug fix : memory leak when include Decimal python data type

### DIFF
--- a/src/mysql_capi_conversion.c
+++ b/src/mysql_capi_conversion.c
@@ -701,8 +701,11 @@ PyObject*
 pytomy_decimal(PyObject *obj)
 {
 #ifdef PY3
-    return PyBytes_FromString((const char *)PyUnicode_1BYTE_DATA(
-                              PyObject_Str(obj)));
+    PyObject *str = PyObject_Str(obj);
+    PyObject *ret_tmp = (const char *)PyUnicode_1BYTE_DATA(str);
+    PyObject *ret = PyBytes_FromString(ret_tmp);
+    Py_DECREF(ret_tmp);
+    return ret;
 #else
     PyObject *numeric, *new_num;
     int tmp_size;


### PR DESCRIPTION
https://bugs.mysql.com/bug.php?id=99517&thanks=2&notify=195

Description:
Memory leak when inserting large amount of data using mysql-connector-python

Memory grows consistently until out-of-memory

In the end I found that this problem only occurs when the Decimal attribute is included