### PR TITLE
Bug fix : memory leak when include Decimal python data type

### DIFF
--- a/src/mysql_capi_conversion.c
+++ b/src/mysql_capi_conversion.c
@@ -702,9 +702,8 @@ pytomy_decimal(PyObject *obj)
 {
 #ifdef PY3
     PyObject *str = PyObject_Str(obj);
-    PyObject *ret_tmp = (const char *)PyUnicode_1BYTE_DATA(str);
-    PyObject *ret = PyBytes_FromString(ret_tmp);
-    Py_DECREF(ret_tmp);
+    PyObject *ret = PyBytes_FromString((const char *)PyUnicode_1BYTE_DATA(str));
+    Py_DECREF(str);
     return ret;
 #else
     PyObject *numeric, *new_num;


### PR DESCRIPTION
https://bugs.mysql.com/bug.php?id=99517&thanks=2&notify=195

Description:
Memory leak when inserting large amount of data using mysql-connector-python

Memory grows consistently until out-of-memory

In the end I found that this problem only occurs when the Decimal attribute is included