### PR TITLE
Fixing 99106 - Django 3 Unsupport backend error

### DIFF
--- a/lib/mysql/connector/django/base.py
+++ b/lib/mysql/connector/django/base.py
@@ -55,8 +55,9 @@ from django.db import utils
 from django.db.backends import utils as backend_utils
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.signals import connection_created
-from django.utils import (six, timezone, dateparse)
+from django.utils import (timezone, dateparse)
 from django.conf import settings
+import six
 
 from mysql.connector.django.client import DatabaseClient
 from mysql.connector.django.creation import DatabaseCreation

--- a/lib/mysql/connector/django/compiler.py
+++ b/lib/mysql/connector/django/compiler.py
@@ -3,7 +3,7 @@
 
 import django
 from django.db.models.sql import compiler
-from django.utils.six.moves import zip_longest
+from six.moves import zip_longest
 
 
 class SQLCompiler(compiler.SQLCompiler):

--- a/lib/mysql/connector/django/features.py
+++ b/lib/mysql/connector/django/features.py
@@ -3,7 +3,7 @@
 import django
 from django.db.backends.base.features import BaseDatabaseFeatures
 from django.utils.functional import cached_property
-from django.utils import six
+import six
 
 try:
     import pytz

--- a/lib/mysql/connector/django/operations.py
+++ b/lib/mysql/connector/django/operations.py
@@ -7,8 +7,9 @@ import uuid
 import django
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
-from django.utils import six, timezone
+from django.utils import timezone
 from django.utils.encoding import force_text
+import six
 
 try:
     from _mysql_connector import datetime_to_mysql, time_to_mysql

--- a/lib/mysql/connector/django/operations.py
+++ b/lib/mysql/connector/django/operations.py
@@ -225,17 +225,17 @@ class DatabaseOperations(BaseDatabaseOperations):
         return converters
 
     def convert_booleanfield_value(self, value,
-                                   expression, connection, context):
+                                   expression, connection, context=None):
         if value in (0, 1):
             value = bool(value)
         return value
 
-    def convert_uuidfield_value(self, value, expression, connection, context):
+    def convert_uuidfield_value(self, value, expression, connection, context=None):
         if value is not None:
             value = uuid.UUID(value)
         return value
 
-    def convert_textfield_value(self, value, expression, connection, context):
+    def convert_textfield_value(self, value, expression, connection, context=None):
         if value is not None:
             value = force_text(value)
         return value


### PR DESCRIPTION
Issue: https://bugs.mysql.com/bug.php?id=99106

This is a result of trying to import `six` from `django.utils.six`. Removal of `six` from utils was in [Django 3 release notes](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis).

This PR simply imports `six` from its own package: [six](https://pypi.org/project/six/)

* Will need to add `six` as a dependency for the lib
* Might be breaking for python<3.0, but given taht python2 EOL has come, this shouldn't be a problem.