### PR TITLE
Keep the same with the converter function in django/db/models/sql/compiler.py in the new version of django.

### DIFF
--- a/lib/mysql/connector/django/operations.py
+++ b/lib/mysql/connector/django/operations.py
@@ -224,17 +224,17 @@ class DatabaseOperations(BaseDatabaseOperations):
         return converters
 
     def convert_booleanfield_value(self, value,
-                                   expression, connection, context):
+                                   expression, connection):
         if value in (0, 1):
             value = bool(value)
         return value
 
-    def convert_uuidfield_value(self, value, expression, connection, context):
+    def convert_uuidfield_value(self, value, expression, connection):
         if value is not None:
             value = uuid.UUID(value)
         return value
 
-    def convert_textfield_value(self, value, expression, connection, context):
+    def convert_textfield_value(self, value, expression, connection):
         if value is not None:
             value = force_text(value)
         return value


### PR DESCRIPTION

If you do not modify it, the following errors will occur.
test env: django==3.0
[File /opt/env/talk/lib/python3.7/site-packages/django/db/models/sql/compiler.py, line 1081, in apply_converters
     value = converter(value, expression, connection)
TypeError: convert_booleanfield_value() missing 1 required positional argument:'context']