### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tests/cext/test_cext_api.py
+++ b/tests/cext/test_cext_api.py
@@ -555,7 +555,7 @@ class CExtMySQLTests(tests.MySQLConnectorTests):
 
         # tests change user
         if tests.MYSQL_VERSION < (8, 0, 0):
-            # 5.6 does noy suport caching_sha2_password auth plugin
+            # 5.6 does noy support caching_sha2_password auth plugin
             test_cases = [(0, 1), (1, 2), (2,3), (3, 0)]
         else:
             test_cases = [(0, 1), (1, 2), (2,3), (3, 0), (3, 4), (4, 5), (5, 3),

--- a/tests/qa/test_qa_mysqlx_collection_replace_remove_one.py
+++ b/tests/qa/test_qa_mysqlx_collection_replace_remove_one.py
@@ -62,7 +62,7 @@ class CollectionReplaceRemoveOneTests(tests.MySQLxTests):
 
     @tests.foreach_session()
     def test_collection_replace_one2(self):
-        """Test replacing multiple values of same doc usingi
+        """Test replacing multiple values of same doc using
         collection.replace_one."""
         self._drop_collection_if_exists("mycoll2")
         collection = self.schema.create_collection("mycoll2")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2280,7 +2280,7 @@ class MySQLConnectionTests(tests.MySQLConnectorTests):
                         "Unexpected exception message found: {}"
                         "".format(context.exception))
 
-        # Verify unkown cipher suite case?
+        # Verify unknown cipher suite case?
         settings["tls_ciphersuites"] = ["NOT-KNOWN"]
         settings["tls_versions"] = ["TLSv1.2"]
         with self.assertRaises(AttributeError) as context:
@@ -2295,7 +2295,7 @@ class MySQLConnectionTests(tests.MySQLConnectorTests):
                         "Unexpected exception message found: {}"
                         "".format(context.exception))
 
-        # Verify unkown cipher suite case?
+        # Verify unknown cipher suite case?
         settings["tls_ciphersuites"] = ["NOT-KNOWN"]
         settings["tls_versions"] = ["TLSv1.2"]
         with self.assertRaises(AttributeError) as context:

--- a/tests/test_mysqlx_connection.py
+++ b/tests/test_mysqlx_connection.py
@@ -607,7 +607,7 @@ class MySQLxSessionTests(tests.MySQLxTests):
                  "MySQL 8.0.13+ is required for connect timeout")
     def test_connect_timeout(self):
         config = self.connect_kwargs.copy()
-        # 0 ms disables timouts on socket connections
+        # 0 ms disables timeouts on socket connections
         config["connect-timeout"] = 0
         session = mysqlx.get_session(config)
         session.close()
@@ -1115,7 +1115,7 @@ class MySQLxSessionTests(tests.MySQLxTests):
                         "Unexpected exception message found: {}"
                         "".format(context.exception.msg))
 
-        # Verify unkown cipher suite case?
+        # Verify unknown cipher suite case?
         settings["tls-ciphersuites"] = ["NOT-KNOWN"]
         settings["tls-versions"] = ["TLSv1.2"]
         with self.assertRaises(InterfaceError) as context:
@@ -1225,7 +1225,7 @@ class MySQLxSessionTests(tests.MySQLxTests):
                         "Unexpected exception message found: {}"
                         "".format(context.exception.msg))
 
-        # Verify unkown cipher suite case?
+        # Verify unknown cipher suite case?
         settings["tls-ciphersuites"] = ["NOT-KNOWN"]
         settings["tls-versions"] = ["TLSv1.2"]
         uri_settings = build_uri(**settings)

--- a/tests/test_mysqlx_crud.py
+++ b/tests/test_mysqlx_crud.py
@@ -2085,13 +2085,13 @@ class MySQLxCollectionTests(tests.MySQLxTests):
         create_index = collection.create_index(index_name, index_desc)
         self.assertRaises(mysqlx.ProgrammingError, create_index.execute)
 
-        # Required inner "field" is misstyped
+        # Required inner "field" is mistyped
         index_desc = {"fields": [{"field1": "$.myField", "type": "TEXT(10)"}],
                       "unique": False, "type":"INDEX"}
         create_index = collection.create_index(index_name, index_desc)
         self.assertRaises(mysqlx.ProgrammingError, create_index.execute)
 
-        # Required inner "field" is misstyped
+        # Required inner "field" is mistyped
         index_desc = {"fields": [{"01field1": "$.myField",
                                   "type": "TEXT(10)"}],
                       "unique": False, "type":"INDEX"}

--- a/tests/test_mysqlx_pooling.py
+++ b/tests/test_mysqlx_pooling.py
@@ -270,7 +270,7 @@ class MySQLxClientTests(tests.MySQLxTests):
                         (total_connections - 2))
 
         if tests.MYSQL_VERSION < (8, 0, 16):
-            # Send reset message requires the user to re-authentificate
+            # Send reset message requires the user to re-authenticate
             # the connection user stays in unauthenticated user
             open_connections = wait_for_connections(old_session,
                                                     "unauthenticated user", 2)
@@ -292,7 +292,7 @@ class MySQLxClientTests(tests.MySQLxTests):
         "Test not available for external MySQL servers",
     )
     def test_max_pool_size(self):
-        """Test exausted pool behavior"""
+        """Test exhausted pool behavior"""
         # Initial pool limit size
         pool_limit = 5
         # Setup a client to get sessions from.
@@ -325,7 +325,7 @@ class MySQLxClientTests(tests.MySQLxTests):
         open_connections = connections.get(self.users[1][0], -1)
         self.assertEqual(len(open_connections), pool_limit)
 
-        # verify exception is raised if the pool is exausted
+        # verify exception is raised if the pool is exhausted
         with self.assertRaises(mysqlx.errors.PoolError):
             client.get_session()
 
@@ -353,13 +353,13 @@ class MySQLxClientTests(tests.MySQLxTests):
         session = client.get_session()
         session.get_schema(settings["schema"])
         session.close()
-        # Verify that clossing the session again does not raise eceptions
+        # Verify that clossing the session again does not raise exceptions
         session.close()
         # Verify that trying to use a closed session raises error
         with self.assertRaises((mysqlx.errors.OperationalError, InterfaceError)):
             session.sql("SELECT 1").execute()
         client.close()
-        # Verify that clossing the client again does not raise eceptions
+        # Verify that clossing the client again does not raise exceptions
         client.close()
 
     @unittest.skipIf(tests.MYSQL_VERSION < (8, 0, 16), "not reset compatible")
@@ -435,7 +435,7 @@ class MySQLxClientTests(tests.MySQLxTests):
 
         # Getting session 4
         session4 = client.get_session()
-        # Verify exception is raised if the pool is exausted
+        # Verify exception is raised if the pool is exhausted
         with self.assertRaises(mysqlx.errors.PoolError):
             client.get_session()
 
@@ -510,7 +510,7 @@ class MySQLxClientTests(tests.MySQLxTests):
                         "Unexpected exception message found: {}"
                         "".format(context.exception.msg))
 
-        # Verify unkown cipher suite case
+        # Verify unknown cipher suite case
         settings["tls-ciphersuites"] = ["NOT-KNOWN"]
         settings["tls-versions"] = ["TLSv1.2"]
         uri_settings = build_uri(**settings)
@@ -917,7 +917,7 @@ class MySQLxConnectionPoolingTests(tests.MySQLxTests):
         connections = get_current_connections(self.session)
         open_connections = connections.get("unauthenticated user", [])
         if tests.MYSQL_VERSION < (8, 0, 16):
-            # Send reset message requires the user to re-authentificate
+            # Send reset message requires the user to re-authenticate
             # the connection user stays in unauthenticated user
             self.assertTrue(len(open_connections) >= 1)
         else:


### PR DESCRIPTION
There are small typos in:
- tests/cext/test_cext_api.py
- tests/qa/test_qa_mysqlx_collection_replace_remove_one.py
- tests/test_connection.py
- tests/test_mysqlx_connection.py
- tests/test_mysqlx_crud.py
- tests/test_mysqlx_pooling.py

Fixes:
- Should read `unknown` rather than `unkown`.
- Should read `exhausted` rather than `exausted`.
- Should read `mistyped` rather than `misstyped`.
- Should read `exceptions` rather than `eceptions`.
- Should read `authenticate` rather than `authentificate`.
- Should read `using` rather than `usingi`.
- Should read `timeouts` rather than `timouts`.
- Should read `support` rather than `suport`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md