### PR TITLE
Report issue about python process got hung on both Windows and Linux begin from 8.0.27 when try to open mysql connection

### DIFF
--- a/lib/mysql/connector/connection_cext.py
+++ b/lib/mysql/connector/connection_cext.py
@@ -176,6 +176,8 @@ class CMySQLConnection(MySQLConnectionAbstract):
 
     def _open_connection(self):
         charset_name = CharacterSet.get_info(self._charset_id)[0]
+        
+        # Don't know what exactly is the problem. But the whole python process hung from here and will never return. The problem start with 8.0.27. Could you help have a look?
         self._cmysql = _mysql_connector.MySQL(  # pylint: disable=E1101,I1101
             buffered=self._buffered,
             raw=self._raw,


### PR DESCRIPTION
After upgrade to 8.0.27, when trying to connection to mysql using this connector, the whole python process hung, and will never return.
The version 8.0.26 is good. Could you help check what is the problem? Thanks.