### PR TITLE
Allow mac to use clang for building

### DIFF
--- a/cpydist/__init__.py
+++ b/cpydist/__init__.py
@@ -654,16 +654,23 @@ class BuildExt(build_ext, BaseCommand):
                 ext.extra_compile_args.append("-Wno-unknown-pragmas")
 
         if os.name != "nt":
-            cmd_gcc_ver = ["gcc", "-v"]
+            if platform.system() == "Darwin":
+                cc = os.environ.get("CC", "clang")
+                cxx = os.environ.get("CXX", "clang++")
+            else:
+                cc = os.environ.get("CC", "gcc")
+                cxx = os.environ.get("CXX", "g++")
+
+            cmd_cc_ver = [cc, "-v"]
             self.log.info("Executing: {0}"
-                          "".format(" ".join(cmd_gcc_ver)))
-            proc = Popen(cmd_gcc_ver, stdout=PIPE,
+                          "".format(" ".join(cmd_cc_ver)))
+            proc = Popen(cmd_cc_ver, stdout=PIPE,
                          universal_newlines=True)
             self.log.info(proc.communicate())
-            cmd_gpp_ver = ["g++", "-v"]
+            cmd_cxx_ver = [cxx, "-v"]
             self.log.info("Executing: {0}"
-                          "".format(" ".join(cmd_gcc_ver)))
-            proc = Popen(cmd_gpp_ver, stdout=PIPE,
+                          "".format(" ".join(cmd_cxx_ver)))
+            proc = Popen(cmd_cxx_ver, stdout=PIPE,
                          universal_newlines=True)
             self.log.info(proc.communicate())
 


### PR DESCRIPTION
It's common for mac to only use clang, and prefer that by default.

It's also possible for package maintainers to provide a specific version of a compiler, especially for cross compilation. This amends the gcc assumption to allow for a broder scope of C compilers.