### PR TITLE
If extra init_command options are given for the Django connector, load them

### DIFF
--- a/lib/mysql/connector/django/client.py
+++ b/lib/mysql/connector/django/client.py
@@ -51,8 +51,9 @@ class DatabaseClient(BaseDatabaseClient):
         if defaults_file:
             args.append('--defaults-file={0}'.format(defaults_file))
 
-        # We force SQL_MODE to TRADITIONAL
-        args.append('--init-command=SET @@session.SQL_MODE=TRADITIONAL')
+        # Load any custom init_commands. We always force SQL_MODE to TRADITIONAL
+        init_command = settings_dict['OPTIONS'].get('init_command', '')
+        args.append('--init-command=SET @@session.SQL_MODE=TRADITIONAL;{0}'.format(init_command))
 
         if user:
             args.append('--user={0}'.format(user))

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -435,7 +435,14 @@ class CustomDjangoMySQLConverterTests(tests.MySQLConnectorTests):
         }
         cnx = self.create_connection()
         cnx.close()
-        del settings.DATABASES['default']['OPTIONS']
+
+    def test_init_command(self):
+        settings.DATABASES["default"]["OPTIONS"] = {
+            "init_command": "SET foo='bar'",
+        }
+        cnx = self.create_connection()
+        cnx.close()
+        del settings.DATABASES["default"]["OPTIONS"]
 
 
 class BugOra20106629(tests.MySQLConnectorTests):


### PR DESCRIPTION
This adds support for the `init_command` option in the Django Database config setting.

Adding this option should now work, previously this was ignored (it does work with the default Django mysqldb connector):
```
{
    "default": {
        "ENGINE": "mysql.connector.django",
        "NAME": DBCONFIG["database"],
        "USER": "user",
        "PASSWORD": "password",
        "HOST": DBCONFIG["host"],
        "PORT": DBCONFIG["port"],
        "OPTIONS": {
            "init_command": "SET foo='bar';"
        }
    }
}
```

I wouldn't normally use the .format() in that way, but I mimicked what was already in the file. If you want to do things differently, let me know.

I've filled out and signed the OCA.
I confirm the code being submitted is offered under the terms of the OCA, and that I am authorized to contribute it.

I've added a test for the Django connector, but I had a hard time getting all tests for the other parts to work locally. Things "should be fine though (tm)"