### PR TITLE
Fix executemany batch insert operations sentinel RE

### DIFF
--- a/lib/mysql/connector/cursor.py
+++ b/lib/mysql/connector/cursor.py
@@ -56,7 +56,7 @@ RE_SQL_ON_DUPLICATE = re.compile(
 RE_SQL_INSERT_STMT = re.compile(
     rf"({SQL_COMMENT}|\s)*INSERT({SQL_COMMENT}|\s)"
     r"*INTO\s+[`'\"]?.+[`'\"]?(?:\.[`'\"]?.+[`'\"]?)"
-    r"{{0,2}}\s+VALUES\s*\(.+(?:\s*,.+)*\)",
+    r"{0,2}\s+VALUES\s*\(.+(?:\s*,.+)*\)",
     re.I | re.M | re.S,
 )
 RE_SQL_INSERT_VALUES = re.compile(r".*VALUES\s*(\(.*\)).*", re.I | re.M | re.S)


### PR DESCRIPTION
The `MySQLCursor.executemany()` method implements a sentinel for detecting batch insert operations and grouping multiple `INSERT` queries into a significantly more performant single `INSERT` query with multiple values.

The current definition of the RE is faulty, causing the sentinel to fail in correctly identifying batch `INSERT` operations. This fault seems to be due to a regression introduced in https://github.com/mysql/mysql-connector-python/commit/ddf6b13704e0e409bb8cac292acc42928501ab46, released as part of [v8.0.30](https://github.com/mysql/mysql-connector-python/releases/tag/8.0.30).

As can be seen in [diff#ddf6b13](https://github.com/mysql/mysql-connector-python/commit/ddf6b13704e0e409bb8cac292acc42928501ab46#diff-7e682aeb16e7aabbb3005f9111de70d64e27330a74aa2dc7e0e6ba6eaaa3e3c3), while the `.format()` invocation was removed from cursor.py#L52, the escaping curly braces for the RE quantifier defined were left behind. Lacking the `.format()` invocation the previously escaping curly braces to the RE quantifier now defined at [lib/mysql/connector/cursor.py#L59](https://github.com/mysql/mysql-connector-python/blob/8.0.30/lib/mysql/connector/cursor.py#L59) have become part of the RE itself, thus breaking the sentinel to always fail identifying batch `INSERT` operations.

This PR fixes the above described regression. The associated MySQL issue tracker bug: https://bugs.mysql.com/bug.php?id=108145&thanks=2&notify=195