### PR TITLE
Remove debug messages that print username/password

### DIFF
--- a/lib/mysql/connector/connection.py
+++ b/lib/mysql/connector/connection.py
@@ -261,8 +261,6 @@ class MySQLConnection(MySQLConnectionAbstract):
                 self._auth_plugin,
             )
 
-        _LOGGER.debug("# _do_auth(): user: %s", username)
-        _LOGGER.debug("# _do_auth(): password: %s", password)
 
         packet = self._protocol.make_auth(
             handshake=self._handshake,


### PR DESCRIPTION
I'm not sure if these message were left here intentionally, but I don't believe they should be here.

An example of how this could go badly is when a user is importing this library, and running with log level == DEBUG, the password will be printed in the logs. Unfortunately this can't be easily disabled, since mysql-connector-python is using `logging.getLogger(__name__)`