### PR TITLE
Fix: connection attributes length shoud be a length-encoded Integer

### DIFF
--- a/lib/mysql/connector/protocol.py
+++ b/lib/mysql/connector/protocol.py
@@ -167,11 +167,11 @@ class MySQLProtocol:
             + len(conn_attrs.values())
         )
 
-        conn_attrs_packet = struct.pack("<B", conn_attrs_len)
+        conn_attrs_packet = utils.lc_int(conn_attrs_len)
         for attr_name in conn_attrs:
-            conn_attrs_packet += struct.pack("<B", len(attr_name))
+            conn_attrs_packet += utils.lc_int(len(attr_name))
             conn_attrs_packet += attr_name.encode("utf8")
-            conn_attrs_packet += struct.pack("<B", len(conn_attrs[attr_name]))
+            conn_attrs_packet += utils.lc_int(len(conn_attrs[attr_name]))
             conn_attrs_packet += conn_attrs[attr_name].encode("utf8")
         return conn_attrs_packet
 


### PR DESCRIPTION
The current code simply add conn_attrs_len to handshake response packet, so when connection attribute has a length bigger than 251, some weird things happen, like below:

```
  File "/Users/left/mysql-connector-python/connector/protocol.py", line 154, in make_auth
    packet += self.make_conn_attrs(conn_attrs)
  File "/Users/left/mysql-connector-python/connector/protocol.py", line 170, in make_conn_attrs
    conn_attrs_packet = struct.pack("<B", conn_attrs_len)
struct.error: ubyte format requires 0 <= number <= 255
```
https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_response.html
According to MySQL document, this length should be a length-encoded Integer:
<img width="735" alt="image" src="https://user-images.githubusercontent.com/7519799/206083258-546c38fa-a9af-4333-b4e8-aaacbb7f717d.png">



BTW, I've already signed the agreement on https://oca.opensource.oracle.com/
