### PR TITLE
cext: Support compression

### DIFF
--- a/src/mysql_capi.c
+++ b/src/mysql_capi.c
@@ -1202,6 +1202,10 @@ MySQL_connect(MySQL *self, PyObject *args, PyObject *kwds)
         mysql_options(&self->session, MYSQL_OPT_LOCAL_INFILE, &denied);
     }
 
+    if (compress != NULL && (PyBool_Check(compress) && compress == Py_True)) {
+        client_flags = client_flags ^ CLIENT_COMPRESS;
+    }
+
     if (client_flags & CLIENT_LOCAL_FILES && (local_infile != 1)) {
         client_flags = client_flags & ~CLIENT_LOCAL_FILES;
     }


### PR DESCRIPTION
Fixes:
    Bug #110879: Compression doesn't work with C extension API
    https://bugs.mysql.com/bug.php?id=110879

Looks like the problem is that the C Extension parses the `compress` option, but doesn't set the `client_flags` which is passed to `mysql_real_connect`.

Script:
```python3
import _mysql_connector

con = _mysql_connector.MySQL()
con.connect(
    host="127.0.0.1",
    user="root",
    password="root",
    compress=True,
)

con.query("SHOW STATUS LIKE 'Compression%'")
while row := con.fetch_row():
    print(row)
con.free_result()

con.close()
```

Output
```
('Compression', 'ON')
('Compression_algorithm', 'zlib')
('Compression_level', '6')
```