### PR TITLE
django: fix method signature of `display_name`

### DIFF
--- a/lib/mysql/connector/django/base.py
+++ b/lib/mysql/connector/django/base.py
@@ -518,8 +518,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):  # pylint: disable=abstract-method
         return True
 
     @cached_property
-    @staticmethod
-    def display_name() -> str:
+    def display_name(self) -> str:
         """Display name."""
         return "MySQL"
 


### PR DESCRIPTION
This is a partial revert of ddf6b13704e0e409bb8cac292acc42928501ab46 Django expects this method to take one argument, if it takes none a TypeError is thrown when running migrations.
```
TypeError: DatabaseWrapper.display_name() takes 0 positional arguments but 1 was given
```