### PR TITLE
Update setup.py requirements for protobuf.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup(
     ],
     ext_modules=EXTENSIONS,
     cmdclass=COMMAND_CLASSES,
-    install_requires=["protobuf>=3.11.0,<=3.20.3"],
+    install_requires=["protobuf>=3.11.0,<=4.21.6"],
     extras_require={
         "dns-srv": ["dnspython>=1.16.0,<=2.3.0"],
         "compression": ["lz4>=2.1.6,<=4.3.2", "zstandard>=0.12.0,<=0.19.0"],


### PR DESCRIPTION
Fixed version conflicts for the protobuf package, required by grpcio-status, in the libraries used by Google to use the GA4 API.