### PR TITLE
Update charset/collation description indicate this is 16-bits, not 8-bits.

### DIFF
--- a/mysql-connector-python/lib/mysql/connector/authentication.py
+++ b/mysql-connector-python/lib/mysql/connector/authentication.py
@@ -102,7 +102,7 @@ class MySQLAuthenticator:
             host: Server host name.
             ssl_options: SSL and TLS connection options (see
                          `network.MySQLSocket.build_ssl_context`).
-            charset: Client charset (see [1]), only the lower 8-bits.
+            charset: Client collation (see [1]).
             client_flags: Integer representing client capabilities flags.
             max_allowed_packet: Maximum packet size.
 
@@ -316,7 +316,7 @@ class MySQLAuthenticator:
             password2: Account's password factor 2.
             password3: Account's password factor 3.
             database: Initial database name for the connection.
-            charset: Client charset (see [1]), only the lower 8-bits.
+            charset: Client collation (see [1]).
             client_flags: Integer representing client capabilities flags.
             max_allowed_packet: Maximum packet size.
             auth_plugin: Authorization plugin name.

--- a/mysql-connector-python/lib/mysql/connector/protocol.py
+++ b/mysql-connector-python/lib/mysql/connector/protocol.py
@@ -306,7 +306,7 @@ class MySQLProtocol:
             username: Account's username.
             password: Account's password.
             database: Initial database name for the connection
-            charset: Client charset (see [2]), only the lower 8-bits.
+            charset: Client collation (see [2]).
             client_flags: Integer representing client capabilities flags.
             max_allowed_packet: Maximum packet size.
             auth_plugin: Authorization plugin name.
@@ -415,7 +415,7 @@ class MySQLProtocol:
         """Make a SSL authentication packet (see [1]).
 
         Args:
-            charset: Client charset (see [2]), only the lower 8-bits.
+            charset: Client collation (see [2]).
             client_flags: Integer representing client capabilities flags.
             max_allowed_packet: Maximum packet size.
 


### PR DESCRIPTION
The `collation` (confusingly called charset in the code, probably because of historical reasons) is 2 bytes, not 1.

Note that the link in the description points to https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_character_set.html#a_protocol_character_set which describes Collations, not Charsets. See also the `SHOW COLLATION` and `SHOW CHARSET` output (or the corresponding I_S tables).

In the code below a [`H` is used](https://docs.python.org/3/library/struct.html#format-characters) to format bytes for `charset` in `struct.pack()`. Also the filler has a length of 22 and not 23 as [the docs](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_response.html) incorrectly list.

https://github.com/mysql/mysql-connector-python/blob/dc71cebe53615110ff00dbb8b629f5457ece1ddb/mysql-connector-python/lib/mysql/connector/protocol.py#L368-L377

https://github.com/mysql/mysql-connector-python/blob/dc71cebe53615110ff00dbb8b629f5457ece1ddb/mysql-connector-python/lib/mysql/connector/protocol.py#L395-L397

And here `utils.int2store()` is used:

https://github.com/mysql/mysql-connector-python/blob/dc71cebe53615110ff00dbb8b629f5457ece1ddb/mysql-connector-python/lib/mysql/connector/protocol.py#L437

See also:
- https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase_packets_protocol_handshake_response.html
- https://bugs.mysql.com/bug.php?id=114818
- http://github.com/mysql/mysql-server/pull/541

