### PR TITLE
caching_sha2_password: Do not send passwords over non-SSL connections

### DIFF
--- a/mysql-connector-python/lib/mysql/connector/plugins/caching_sha2_password.py
+++ b/mysql-connector-python/lib/mysql/connector/plugins/caching_sha2_password.py
@@ -101,7 +101,9 @@ class MySQLCachingSHA2PasswordAuthPlugin(MySQLAuthPlugin):
         if len(auth_data) > 1:
             return self._scramble(auth_data)
         if auth_data[0] == self.perform_full_authentication:
-            # return password as clear text.
+            # return password as clear text if SSL is enabled.
+            if not self.ssl_enabled:
+                raise InterfaceError(f"{self.name} full authentication requires SSL")
             return self._password.encode() + b"\x00"
 
         return None


### PR DESCRIPTION
When server requests full authentication, ensure we only send the password if the connection is over SSL, otherwise the password is in the plain and authentication anyhow fails.

This only impacts users that explicitly set ssl_disabled=True, a plain password on the wire is still very surprising given the RSA infrastructure as a fallback that other clients use.