### PR TITLE
fix connect failed when total length of conn_attr exceeds 251

### DIFF
--- a/mysql-connector-python/lib/mysql/connector/protocol.py
+++ b/mysql-connector-python/lib/mysql/connector/protocol.py
@@ -68,6 +68,7 @@ from .types import (
     StatsPacketType,
     StrOrBytes,
 )
+from .utils import lc_int
 
 if TYPE_CHECKING:
     from .network import MySQLSocket
@@ -190,11 +191,11 @@ class MySQLProtocol:
             + len(conn_attrs.values())
         )
 
-        conn_attrs_packet = [struct.pack("<B", conn_attrs_len)]
+        conn_attrs_packet = [lc_int(conn_attrs_len)]
         for attr_name in conn_attrs:
-            conn_attrs_packet.append(struct.pack("<B", len(attr_name)))
+            conn_attrs_packet.append(lc_int(len(attr_name)))
             conn_attrs_packet.append(attr_name.encode())
-            conn_attrs_packet.append(struct.pack("<B", len(conn_attrs[attr_name])))
+            conn_attrs_packet.append(lc_int(len(conn_attrs[attr_name])))
             conn_attrs_packet.append(conn_attrs[attr_name].encode())
         return b"".join(conn_attrs_packet)
 


### PR DESCRIPTION
When connect to mysql with conn_attrs, if the total length of conn_attrs exceeds 251, python connector fails with

>  conn_attrs_packet = [struct.pack("<B", conn_attrs_len)]
>                         ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
> struct.error: 'B' format requires 0 <= number <= 255

This PR fixes this by using `lc_int` instead of `struct.pack("<B")`.

One can easily reproduce this by setting a lot of attrs, below is the example.
Actually, python connector failed to connect on my Mac with a long device name even not setting any conn_attrs, because the connector will auto send some platform info in attrs, and the total length exceeds 251.

```
import mysql.connector

# Create a database connection to a MySQL database.
conn_attr = {
    'host': 'localhost',        # Replace with your host
    'user': 'your_username',    # Replace with your username
    'password': 'your_password', # Replace with your password
    'use_pure': True,             # Use pure Python implementation
    'ssl_disabled': True,
    'conn_attrs': {
        'foooooo': 'barrrrr',
        'foooooo1': 'barrrrr',
        'foooooo2': 'barrrrr',
        'foooooo3': 'barrrrr',
        'foooooo4': 'barrrrr',
        'foooooo5': 'barrrrr',
        'foooooo6': 'barrrrr',
    }
}

# Create a connection
connection = mysql.connector.connect(**conn_attr)

# Perform database operations here
cursor = connection.cursor()
cursor.execute("SHOW DATABASES;")  # Change the statement to show databases
databases = cursor.fetchall()  # Fetch all databases

print("Databases:")
for database in databases:
    print(database[0])  # Print each database name

    # Close the cursor and connection
    cursor.close()
    connection.close()
```